### PR TITLE
Add publishing to homebrew repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,10 @@ script:
   - env GO111MODULE=on go test -v -cover github.com/schollz/croc/v6/src/utils
   - env GO111MODULE=on go test -v -cover github.com/schollz/croc/v6/src/comm
   
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: curl -sL https://git.io/goreleaser | bash
+    on:
+      tags: true
+      condition: $TRAVIS_OS_NAME = linux

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ $ go get -v github.com/schollz/croc/v6
 ```
 
 
+Or, on macOS you can install the latest release with [Homebrew](https://brew.sh/): 
+
+```
+$ brew install schollz/tap/croc
+```
+
+
 
 ## Usage 
 

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -62,3 +62,19 @@ archive:
   files:
     - README.md
     - LICENSE
+
+brew:
+  github:
+    owner: schollz
+    name: homebrew-tap
+  folder: Formula
+  description: "croc is a tool that allows any two computers to simply and securely transfer files and folders."
+  homepage: "https://schollz.com/software/croc/"
+  install: |
+    bin.install "croc"
+
+  dependencies:
+    - caddy
+
+  test: |
+    system "#{bin}/croc --version"


### PR DESCRIPTION
I hope you are interested adding a pipeline to publishing to your own homebrew repository.

These are probable issues:
1. Is "caddy" the correct dependency with the correct version?
2. Do need Bash Completions no installation statement in homebrew?

These steps are needed to complete the pull request:
1. Create Repository "homebrew-tap"
2. Grant Access for Travis CI
<img width="381" alt="Screenshot 2019-05-10 at 12 23 39" src="https://user-images.githubusercontent.com/3398801/57521475-ac65a100-7320-11e9-8b6e-65452c833a74.png">