### PR TITLE
Add publishing to scoop bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,25 @@ $ curl https://getcroc.schollz.com | bash
 ```
 
 
+On macOS you can install the latest release with [Homebrew](https://brew.sh/): 
+
+```
+$ brew install schollz/tap/croc
+```
+
+
+On Windows you can install the latest release with [Scoop](https://scoop.sh/): 
+
+```
+$ scoop bucket add schollz-bucket https://github.com/schollz/scoop-bucket.git
+$ scoop install croc
+```
+
+
 Or, you can [install Go](https://golang.org/dl/) and build from source (requires Go 1.11+): 
 
 ```
 $ go get -v github.com/schollz/croc/v6
-```
-
-
-Or, on macOS you can install the latest release with [Homebrew](https://brew.sh/): 
-
-```
-$ brew install schollz/tap/croc
 ```
 
 

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -76,3 +76,11 @@ brew:
 
   test: |
     system "#{bin}/croc --version"
+
+scoop:
+  bucket:
+    owner: schollz
+    name: scoop-bucket
+  homepage: "https://schollz.com/software/croc/"
+  description: "croc is a tool that allows any two computers to simply and securely transfer files and folders."
+  license: MIT


### PR DESCRIPTION
I hope you are interested adding a pipeline to publishing to your own scoop bucket.

These steps are needed to complete the Pull Request:

1. Create Repository "scoop-bucket".
2. Access for Travis CI should be already granted.

Naming and README for the repository "scoop-bucket" are opinionated and are based on "homebrew-tap" structure.
A probable README could be:
```markdown
schollz Scoop Bucket
====================

This is a [Scoop](https://scoop.sh) bucket for manifests for software developed by schollz.


Setup
-----

Using these manifests requires Scoop.

Once Scoop is installed, simply run:

    scoop bucket add schollz-bucket https://github.com/schollz/scoop-bucket.git
```