### PR TITLE
update clone url

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ scoop install croc
 Or, you can [install Go](https://golang.org/dl/) and build from source (requires Go 1.11+): 
 
 ```
-$ go get -v github.com/schollz/croc/v6
+$ go get -v github.com/schollz/croc
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ scoop install croc
 Or, you can [install Go](https://golang.org/dl/) and build from source (requires Go 1.11+): 
 
 ```
-$ go get -v github.com/schollz/croc
+$ GO111MODULE=on go get -u -v github.com/schollz/croc/v6
 ```
 
 


### PR DESCRIPTION
Unless I'm doing something wrong, /v6 isn't needed:
```
$ go get -v github.com/schollz/croc/v6
github.com/schollz/croc (download)
package github.com/schollz/croc/v6: cannot find package "github.com/schollz/croc/v6" in any of:
        /usr/local/go/src/github.com/schollz/croc/v6 (from $GOROOT)
        /home/jungleboogie/gopath/src/github.com/schollz/croc/v6 (from $GOPATH)
```