### PR TITLE
Install Script FreeBSD Support and Checksum Checks Fixes

### DIFF
--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -144,7 +144,7 @@ install_croc()
 
 	echo "Verifying checksum..."
 	if [[ $unameu == *DARWIN* ]]; then
-    checksum="$(shasum -a 256 ${dl}) $croc_file)"
+    checksum="$(shasum -a 256 ${dl}) $croc_file"
   elif [[ $unameu == "FREEBSD" ]]; then
     checksum="$(sha256 -q ${dl})  $croc_file"
 	else

--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -144,7 +144,7 @@ install_croc()
 
 	echo "Verifying checksum..."
 	if [[ $unameu == *DARWIN* ]]; then
-    checksum="$(shasum -a 256 ${dl}) $croc_file"
+    checksum="$(shasum -a 256 ${dl})"
   elif [[ $unameu == "FREEBSD" ]]; then
     checksum="$(sha256 -q ${dl})  $croc_file"
 	else

--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -97,7 +97,7 @@ install_croc()
 	elif [[ $unameu == *LINUX* ]]; then
 		croc_os="Linux"
 	elif [[ $unameu == *FREEBSD* ]]; then
-		croc_os="freebsd"
+		croc_os="FreeBSD"
 	elif [[ $unameu == *NETBSD* ]]; then
 		croc_os="NetBSD"
 	elif [[ $unameu == *OPENBSD* ]]; then
@@ -144,17 +144,23 @@ install_croc()
 
 	echo "Verifying checksum..."
 	if [[ $unameu == *DARWIN* ]]; then
-		checksum="$(shasum -a 256 ${dl}) $croc_file"
+    checksum="$(shasum -a 256 ${dl}) $croc_file)"
+  elif [[ $unameu == "FREEBSD" ]]; then
+    checksum="$(sha256 -q ${dl})  $croc_file"
 	else
-		checksum="$(sha256sum ${dl}) $croc_file"
+		checksum="$(sha256sum ${dl})"
 	fi
-	checksum_check="$(cat ${dl_checksum} | grep $croc_file) $croc_file"
+	checksum_check="$(cat ${dl_checksum} | grep "${checksum}")"
 
-	if [[ "$s1" != "$s2" ]]; then
+	if [[ "${checksum}" != "${checksum_check}" ]]; then
 		echo "${checksum}"
 		echo "${checksum_check}"
 		echo "checksums are not valid, exiting"
 		return 7
+  else
+    echo "verified checksum"
+    echo "Downloaded: ${checksum}"
+    echo "Remote:     ${checksum_check}"
 	fi
 
 


### PR DESCRIPTION
Adding in some fixes for FreeBSD (tested in a FreeNAS jail 'FreeBSD 11.2-STABLE') as well as a fix for the checksum logic not correctly comparing the checksums.

Before/If this PR is accepted, I plan to do more testing on this to make sure it still works on all supported platforms.

So far I've tested on FreeBSD 11.2-STABLE and CentOS 7.6.1810

Need to find a MacOS host to test on still.