### PR TITLE
Adding in a more detailed error message for when an extraction tool is not found.

### DIFF
--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -23,7 +23,7 @@
 #                  Issues: https://github.com/schollz/croc/issues
 #
 #       CREATED: 08/10/2019 16:41
-#      REVISION: 0.9.0
+#      REVISION: 0.9.1
 #===============================================================================
 set -o nounset                              # Treat unset variables as an error
 
@@ -330,7 +330,7 @@ extract_file() {
                  tar -xf "${file}" -C "${dir}"
                  rcode="${?}"
                else
-                 rcode="30"
+                 rcode="31"
                fi
                ;;
            * ) rcode="20";;
@@ -610,7 +610,10 @@ main() {
     print_message "== Failed to determine which extraction tool to use" "error"
     exit 1
   elif [[ "${extract_file_rcode}" == "30" ]]; then
-    print_message "== Failed to find extraction tool in path" "error"
+    print_message "== Failed to find 'unzip' in path" "error"
+    exit 1
+  elif [[ "${extract_file_rcode}" == "31" ]]; then
+    print_message "== Failed to find 'tar' in path" "error"
     exit 1
   else
     print_message "== Unknown error returned from extraction attempt" "error"


### PR DESCRIPTION
Ran into this when I was installing croc on a CentOS 8 minimal install.

`tar` apparently did not make the 'minimal' cut, and the old error message of

> Failed to find extraction tool in path

was too vague for my liking. :smile:

Once I installed `tar` the installer worked fine :tada: 