### PR TITLE
Add Arch Linux installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ $ scoop install croc
 ```
 
 
+On Arch Linux you can install the latest release with `pacman`:
+
+```
+$ pacman -S croc
+```
+
 Or, you can [install Go](https://golang.org/dl/) and build from source (requires Go 1.12+): 
 
 ```


### PR DESCRIPTION
Thanks for this nice tool 👍 
I'm [packaging `croc`](https://www.archlinux.org/packages/community/x86_64/croc/) for Arch Linux, adding this to README to help people discover this fact 🙂 