### PR TITLE
croc is now available in the main scoop bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ $ brew install schollz/tap/croc
 On Windows you can install the latest release with [Scoop](https://scoop.sh/): 
 
 ```
-$ scoop bucket add schollz-bucket https://github.com/schollz/scoop-bucket.git
 $ scoop install croc
 ```
 


### PR DESCRIPTION
No need to add dedicated channel as it is available in the main bucket.
See: https://github.com/ScoopInstaller/Main/blob/master/bucket/croc.json