### PR TITLE
Add version to the dir name in the source tarball

### DIFF
--- a/src/install/prepare-sources-tarball.sh
+++ b/src/install/prepare-sources-tarball.sh
@@ -2,7 +2,7 @@
 tmp=$(mktemp -d)
 VERSION=$(cat ./src/cli/cli.go | grep 'Version = "v' | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 echo $VERSION
-git clone --depth 1 https://github.com/schollz/croc $tmp/croc-${VERSION}
+git clone -b v${VERSION} --depth 1 https://github.com/schollz/croc $tmp/croc-${VERSION}
 (cd $tmp/croc-${VERSION} && go mod tidy && go mod vendor)
 (cd $tmp && tar -cvzf croc_${VERSION}_src.tar.gz croc-${VERSION})
 mv $tmp/croc_${VERSION}_src.tar.gz dist/

--- a/src/install/prepare-sources-tarball.sh
+++ b/src/install/prepare-sources-tarball.sh
@@ -2,7 +2,7 @@
 tmp=$(mktemp -d)
 VERSION=$(cat ./src/cli/cli.go | grep 'Version = "v' | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 echo $VERSION
-git clone --depth 1 https://github.com/schollz/croc $tmp/croc
-(cd $tmp/croc && go mod tidy && go mod vendor)
-(cd $tmp && tar -cvzf croc_${VERSION}_src.tar.gz croc)
+git clone --depth 1 https://github.com/schollz/croc $tmp/croc-${VERSION}
+(cd $tmp/croc-${VERSION} && go mod tidy && go mod vendor)
+(cd $tmp && tar -cvzf croc_${VERSION}_src.tar.gz croc-${VERSION})
 mv $tmp/croc_${VERSION}_src.tar.gz dist/


### PR DESCRIPTION
Just a final touch to #172, when you unarchive the src tarball, you want the contents to be placed in a unique directory, not potentially be mixed with the unarchived old version.