### PR TITLE
Adding a function that creates the prefix

### DIFF
--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -340,6 +340,23 @@ extract_file() {
 }
 
 #---  FUNCTION  ----------------------------------------------------------------
+#          NAME:  create_prefix
+#   DESCRIPTION:  Creates the install prefix (and any parent directories)
+#    PARAMETERS:  $1 = prefix
+#       RETURNS:  Return code of the tool used to make the directory
+#                 0 = Created the directory
+#                 >0 = Failed to create directory  
+#-------------------------------------------------------------------------------
+create_prefix() {
+  local prefix
+  local rcode
+
+  prefix="${1}"
+  
+  mkdir -p "${prefix}"
+}
+
+#---  FUNCTION  ----------------------------------------------------------------
 #          NAME:  install_file_freebsd
 #   DESCRIPTION:  Installs a file into a location using 'install'.  If EUID not
 #                 0, then attempt to use sudo.
@@ -376,7 +393,6 @@ install_file_freebsd() {
 
   return "${rcode}"
 }
-
 
 #---  FUNCTION  ----------------------------------------------------------------
 #          NAME:  install_file_linux
@@ -485,6 +501,7 @@ main() {
   local checksum_check_rcode
   local extract_file_rcode
   local install_file_rcode
+  local create_prefix_rcode
 
   croc_bin_name="croc"
   croc_version="6.4.6"
@@ -619,6 +636,20 @@ main() {
     print_message "== Unknown error returned from extraction attempt" "error"
     exit 1
   fi
+
+  if [[ ! -d "${prefix}" ]]; then
+    create_prefix "${prefix}"
+    create_prefix_rcode="${?}"
+    if [[ "${create_prefix_rcode}" -gt 0 ]]; then
+      print_message "== Failed to create the install prefix: ${prefix}" "error"
+      exit 1
+    else
+      print_message "== Created install prefix at ${prefix}" "info"
+    fi
+  else
+    print_message "== Install prefix already exists. No need to create it." "info"
+  fi
+
 
   case "${croc_os}" in
     "Linux" ) install_file_linux "${tmpdir}/${croc_bin_name}" "${prefix}/";

--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -354,6 +354,9 @@ create_prefix() {
   prefix="${1}"
   
   mkdir -p "${prefix}"
+  rcode="${?}"
+
+  return "${rcode}"
 }
 
 #---  FUNCTION  ----------------------------------------------------------------

--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -341,20 +341,36 @@ extract_file() {
 
 #---  FUNCTION  ----------------------------------------------------------------
 #          NAME:  create_prefix
-#   DESCRIPTION:  Creates the install prefix (and any parent directories)
+#   DESCRIPTION:  Creates the install prefix (and any parent directories). If
+#                 EUID not 0, then attempt to use sudo.
 #    PARAMETERS:  $1 = prefix
 #       RETURNS:  Return code of the tool used to make the directory
 #                 0 = Created the directory
 #                 >0 = Failed to create directory  
+#                 20 = Could not find mkdir command
+#                 21 = Could not find sudo command
 #-------------------------------------------------------------------------------
 create_prefix() {
   local prefix
   local rcode
 
   prefix="${1}"
-  
-  mkdir -p "${prefix}"
-  rcode="${?}"
+
+  if command -v mkdir >/dev/null 2>&1; then
+    if [[ "${EUID}" == "0" ]]; then
+      mkdir -p "${prefix}"
+      rcode="${?}"
+    else
+      if command -v sudo >/dev/null 2>&1; then
+        sudo mkdir -p "${prefix}"
+        rcode="${?}"
+      else
+        rcode="21"
+      fi
+    fi
+  else
+    rcode="20"
+  fi
 
   return "${rcode}"
 }
@@ -643,11 +659,17 @@ main() {
   if [[ ! -d "${prefix}" ]]; then
     create_prefix "${prefix}"
     create_prefix_rcode="${?}"
-    if [[ "${create_prefix_rcode}" -gt 0 ]]; then
-      print_message "== Failed to create the install prefix: ${prefix}" "error"
+    if [[ "${create_prefix_rcode}" == "0" ]]; then
+      print_message "== Created install prefix at ${prefix}" "info"
+    elif [[ "${create_prefix_rcode}" == "20" ]]; then
+      print_message "== Failed to find mkdir in path" "error"
+      exit 1
+    elif [[ "${create_prefix_rcode}" == "21" ]]; then
+      print_message "== Failed to find sudo in path" "error"
       exit 1
     else
-      print_message "== Created install prefix at ${prefix}" "info"
+      print_message "== Failed to create the install prefix: ${prefix}" "error"
+      exit 1
     fi
   else
     print_message "== Install prefix already exists. No need to create it." "info"


### PR DESCRIPTION
This is in response to https://github.com/schollz/croc/issues/182

Also creates logic to only create it if it does not already exist.

My only issue with this is using the `-p` flag on `mkdir`.  Something about a script auto-creating something by default makes me uneasy, though that could be just my paranoid sysadmin side coming out.

I guess so long as the script output mentions the fact it created it (the prefix in this case) then I'm more comfortable with it.

Thoughts?

OH!  And I don't have access to a Mac so this was tested with some assumptions made. It should probably get some testing on a fresh mac install.