### PR TITLE
croc: secret phrase parsing

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -304,8 +304,15 @@ func receive(c *cli.Context) (err error) {
 		Ask:           c.GlobalBool("ask"),
 		RelayPassword: c.GlobalString("pass"),
 	}
-	if c.Args().First() != "" {
+
+	switch len(c.Args()) {
+	case 1:
 		crocOptions.SharedSecret = c.Args().First()
+	case 3:
+		var phrase []string
+		phrase = append(phrase, c.Args().First())
+		phrase = append(phrase, c.Args().Tail()...)
+		crocOptions.SharedSecret = strings.Join(phrase, "-")
 	}
 
 	// load options here


### PR DESCRIPTION
what:
- `croc alpha beta gamma` is now properly understood as
 `croc alpha-beta-gamma`.

why:
- to increase convenience.