### PR TITLE
relay: show version on startup

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -380,6 +380,7 @@ func receive(c *cli.Context) (err error) {
 }
 
 func relay(c *cli.Context) (err error) {
+	log.Infof("starting croc relay version %v", Version)
 	debugString := "info"
 	if c.GlobalBool("debug") {
 		debugString = "debug"


### PR DESCRIPTION
Since relay is a long-running process, I find myself in situations where I dont know which version of croc I have running.

This simple startup log will make it obvious.