### PR TITLE
Initial IPv6 fixes

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -350,7 +350,9 @@ func receive(c *cli.Context) (err error) {
 		crocOptions.SharedSecret = utils.GetInput("Enter receive code: ")
 	}
 	if c.GlobalString("out") != "" {
-		os.Chdir(c.GlobalString("out"))
+		if err = os.Chdir(c.GlobalString("out")); err != nil {
+			return err
+		}
 	}
 
 	cr, err := croc.New(crocOptions)

--- a/src/comm/comm_test.go
+++ b/src/comm/comm_test.go
@@ -12,7 +12,9 @@ import (
 
 func TestComm(t *testing.T) {
 	token := make([]byte, MAXBYTES)
-	rand.Read(token)
+	if _, err := rand.Read(token); err != nil {
+		t.Error(err)
+	}
 
 	port := "8001"
 	go func() {

--- a/src/compress/compress.go
+++ b/src/compress/compress.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"compress/flate"
 	"io"
+
+	log "github.com/schollz/logger"
 )
 
 // CompressWithOption returns compressed data using the specified level
@@ -31,13 +33,17 @@ func Decompress(src []byte) []byte {
 // compress uses flate to compress a byte slice to a corresponding level
 func compress(src []byte, dest io.Writer, level int) {
 	compressor, _ := flate.NewWriter(dest, level)
-	compressor.Write(src)
+	if _, err := compressor.Write(src); err != nil {
+		log.Errorf("error writing data: %v", err)
+	}
 	compressor.Close()
 }
 
 // compress uses flate to decompress an io.Reader
 func decompress(src io.Reader, dest io.Writer) {
 	decompressor := flate.NewReader(src)
-	io.Copy(dest, decompressor)
+	if _, err := io.Copy(dest, decompressor); err != nil {
+		log.Errorf("error copying data: %v", err)
+	}
 	decompressor.Close()
 }

--- a/src/compress/compress_test.go
+++ b/src/compress/compress_test.go
@@ -51,7 +51,9 @@ func BenchmarkCompressLevelNine(b *testing.B) {
 
 func BenchmarkCompressLevelMinusTwoBinary(b *testing.B) {
 	data := make([]byte, 1000000)
-	rand.Read(data)
+	if _, err := rand.Read(data); err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < b.N; i++ {
 		CompressWithOption(data, -2)
 	}
@@ -59,7 +61,9 @@ func BenchmarkCompressLevelMinusTwoBinary(b *testing.B) {
 
 func BenchmarkCompressLevelNineBinary(b *testing.B) {
 	data := make([]byte, 1000000)
-	rand.Read(data)
+	if _, err := rand.Read(data); err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < b.N; i++ {
 		CompressWithOption(data, 9)
 	}
@@ -83,12 +87,16 @@ func TestCompress(t *testing.T) {
 	assert.True(t, len(compressedB) < len(fable))
 
 	data := make([]byte, 4096)
-	rand.Read(data)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
 	compressedB = CompressWithOption(data, -2)
 	dataRateSavings = 100 * (1.0 - float64(len(compressedB))/float64(len(data)))
 	fmt.Printf("random, Level -2: %2.0f%% percent space savings\n", dataRateSavings)
 
-	rand.Read(data)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
 	compressedB = CompressWithOption(data, 9)
 	dataRateSavings = 100 * (1.0 - float64(len(compressedB))/float64(len(data)))
 

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -12,8 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
 func init() {
 	log.SetLevel("trace")
+
 	go tcp.Run("debug", "8081", "pass123", "8082,8083,8084,8085")
 	go tcp.Run("debug", "8082", "pass123")
 	go tcp.Run("debug", "8083", "pass123")
@@ -59,14 +66,20 @@ func TestCrocReadme(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		sender.Send(TransferOptions{
+		err := sender.Send(TransferOptions{
 			PathToFiles: []string{"../../README.md"},
 		})
+		if err != nil {
+			t.Errorf("send failed: %v", err)
+		}
 		wg.Done()
 	}()
 	time.Sleep(100 * time.Millisecond)
 	go func() {
-		receiver.Receive()
+		err := receiver.Receive()
+		if err != nil {
+			t.Errorf("receive failed: %v", err)
+		}
 		wg.Done()
 	}()
 
@@ -115,15 +128,21 @@ func TestCrocLocal(t *testing.T) {
 	os.Create("touched")
 	wg.Add(2)
 	go func() {
-		sender.Send(TransferOptions{
+		err := sender.Send(TransferOptions{
 			PathToFiles:      []string{"../../LICENSE", "touched"},
 			KeepPathInRemote: false,
 		})
+		if err != nil {
+			t.Errorf("send failed: %v", err)
+		}
 		wg.Done()
 	}()
 	time.Sleep(100 * time.Millisecond)
 	go func() {
-		receiver.Receive()
+		err := receiver.Receive()
+		if err != nil {
+			t.Errorf("send failed: %v", err)
+		}
 		wg.Done()
 	}()
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -125,7 +125,7 @@ func LocalIP() string {
 
 // GetRandomName returns mnemoicoded random name
 func GetRandomName() string {
-	result := []string{}
+	var result []string
 	bs := make([]byte, 4)
 	rand.Read(bs)
 	result = mnemonicode.EncodeWordList(result, bs)
@@ -157,7 +157,7 @@ func MissingChunks(fname string, fsize int64, chunkSize int) (chunkRanges []int6
 	defer f.Close()
 
 	fstat, err := os.Stat(fname)
-	if fstat.Size() != fsize || err != nil {
+	if err != nil || fstat.Size() != fsize {
 		return
 	}
 

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -165,14 +165,14 @@ func TestHashFile(t *testing.T) {
 func TestPublicIP(t *testing.T) {
 	ip, err := PublicIP()
 	fmt.Println(ip)
-	assert.True(t, strings.Contains(ip, "."))
+	assert.True(t, strings.Contains(ip, ".") || strings.Contains(ip, ":"))
 	assert.Nil(t, err)
 }
 
 func TestLocalIP(t *testing.T) {
 	ip := LocalIP()
 	fmt.Println(ip)
-	assert.True(t, strings.Contains(ip, "."))
+	assert.True(t, strings.Contains(ip, ".") || strings.Contains(ip, ":"))
 }
 
 func TestGetRandomName(t *testing.T) {


### PR DESCRIPTION
I found the main cause of IPv6 not working. With this patch, I can run my own relay with an IPv6 address, and transfer a file over IPv6:

```
Sending 'Postgres-2.3.5-12.dmg' (65.4 MB)
Code is: common-imitate-crown
On the other computer run

croc --relay [2605:a601:ab68:2f00:10de:5bb6:4ccb:4936]:9009 common-imitate-crown

Sending (->[2605:a601:ab68:2f00:10de:5bb6:4ccb:4936]:55968)
Postgres-2.3.5-12.dmg  19% |███                 | (12/62 MB, 121.130 MB/s) [0s:0
Postgres-2.3.5-12.dmg  38% |███████             | (24/62 MB, 120.360 MB/s) [0s:0
Postgres-2.3.5-12.dmg  58% |███████████         | (37/62 MB, 121.620 MB/s) [0s:0
Postgres-2.3.5-12.dmg  77% |███████████████     | (48/62 MB, 120.987 MB/s) [0s:0
Postgres-2.3.5-12.dmg  97% |███████████████████ | (61/62 MB, 121.740 MB/s) [0s:0
Postgres-2.3.5-12.dmg 100% |████████████████████| (62/62 MB, 121.732 MB/s) [0s:0s] ✔️
```

```
croc --relay "[2605:a601:ab68:2f00:10de:5bb6:4ccb:4936]:9009" common-imitate-crown

Accept 'Postgres-2.3.5-12.dmg' (65.4 MB)? (y/n) y

Receiving (<-[2605:a601:ab68:2f00:10de:5bb6:4ccb:4936]:55958)
Postgres-2.3.5-12.dmg  19% |███                 | (12/62 MB, 119.181 MB/s) [0s:0
Postgres-2.3.5-12.dmg  38% |███████             | (24/62 MB, 119.272 MB/s) [0s:0
Postgres-2.3.5-12.dmg  58% |███████████         | (36/62 MB, 120.747 MB/s) [0s:0
Postgres-2.3.5-12.dmg  77% |███████████████     | (48/62 MB, 120.538 MB/s) [0s:0
Postgres-2.3.5-12.dmg  97% |███████████████████ | (61/62 MB, 121.256 MB/s) [0s:0
Postgres-2.3.5-12.dmg 100% |████████████████████| (62/62 MB, 121.308 MB/s) [0s:0s] ✔️
```
