### PR TITLE
Improve error reporting

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -350,7 +350,9 @@ func receive(c *cli.Context) (err error) {
 		crocOptions.SharedSecret = utils.GetInput("Enter receive code: ")
 	}
 	if c.GlobalString("out") != "" {
-		os.Chdir(c.GlobalString("out"))
+		if err = os.Chdir(c.GlobalString("out")); err != nil {
+			return err
+		}
 	}
 
 	cr, err := croc.New(crocOptions)

--- a/src/comm/comm_test.go
+++ b/src/comm/comm_test.go
@@ -12,7 +12,9 @@ import (
 
 func TestComm(t *testing.T) {
 	token := make([]byte, MAXBYTES)
-	rand.Read(token)
+	if _, err := rand.Read(token); err != nil {
+		t.Error(err)
+	}
 
 	port := "8001"
 	go func() {

--- a/src/compress/compress.go
+++ b/src/compress/compress.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"compress/flate"
 	"io"
+
+	log "github.com/schollz/logger"
 )
 
 // CompressWithOption returns compressed data using the specified level
@@ -31,13 +33,17 @@ func Decompress(src []byte) []byte {
 // compress uses flate to compress a byte slice to a corresponding level
 func compress(src []byte, dest io.Writer, level int) {
 	compressor, _ := flate.NewWriter(dest, level)
-	compressor.Write(src)
+	if _, err := compressor.Write(src); err != nil {
+		log.Errorf("error writing data: %v", err)
+	}
 	compressor.Close()
 }
 
 // compress uses flate to decompress an io.Reader
 func decompress(src io.Reader, dest io.Writer) {
 	decompressor := flate.NewReader(src)
-	io.Copy(dest, decompressor)
+	if _, err := io.Copy(dest, decompressor); err != nil {
+		log.Errorf("error copying data: %v", err)
+	}
 	decompressor.Close()
 }

--- a/src/compress/compress_test.go
+++ b/src/compress/compress_test.go
@@ -51,7 +51,9 @@ func BenchmarkCompressLevelNine(b *testing.B) {
 
 func BenchmarkCompressLevelMinusTwoBinary(b *testing.B) {
 	data := make([]byte, 1000000)
-	rand.Read(data)
+	if _, err := rand.Read(data); err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < b.N; i++ {
 		CompressWithOption(data, -2)
 	}
@@ -59,7 +61,9 @@ func BenchmarkCompressLevelMinusTwoBinary(b *testing.B) {
 
 func BenchmarkCompressLevelNineBinary(b *testing.B) {
 	data := make([]byte, 1000000)
-	rand.Read(data)
+	if _, err := rand.Read(data); err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < b.N; i++ {
 		CompressWithOption(data, 9)
 	}
@@ -83,12 +87,16 @@ func TestCompress(t *testing.T) {
 	assert.True(t, len(compressedB) < len(fable))
 
 	data := make([]byte, 4096)
-	rand.Read(data)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
 	compressedB = CompressWithOption(data, -2)
 	dataRateSavings = 100 * (1.0 - float64(len(compressedB))/float64(len(data)))
 	fmt.Printf("random, Level -2: %2.0f%% percent space savings\n", dataRateSavings)
 
-	rand.Read(data)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
 	compressedB = CompressWithOption(data, 9)
 	dataRateSavings = 100 * (1.0 - float64(len(compressedB))/float64(len(data)))
 

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -18,7 +18,13 @@ import (
 	"time"
 
 	"github.com/denisbrodbeck/machineid"
-	"github.com/pkg/errors"
+	log "github.com/schollz/logger"
+	"github.com/schollz/pake/v2"
+	"github.com/schollz/peerdiscovery"
+	"github.com/schollz/progressbar/v3"
+	"github.com/schollz/spinner"
+	"github.com/tscholl2/siec"
+
 	"github.com/schollz/croc/v8/src/comm"
 	"github.com/schollz/croc/v8/src/compress"
 	"github.com/schollz/croc/v8/src/crypt"
@@ -26,12 +32,6 @@ import (
 	"github.com/schollz/croc/v8/src/models"
 	"github.com/schollz/croc/v8/src/tcp"
 	"github.com/schollz/croc/v8/src/utils"
-	log "github.com/schollz/logger"
-	"github.com/schollz/pake/v2"
-	"github.com/schollz/peerdiscovery"
-	"github.com/schollz/progressbar/v3"
-	"github.com/schollz/spinner"
-	"github.com/tscholl2/siec"
 )
 
 func init() {
@@ -267,7 +267,7 @@ func (c *Client) broadcastOnLocalNetwork() {
 	log.Debugf("discoveries: %+v", discoveries)
 
 	if err != nil {
-		log.Debug(err.Error())
+		log.Debug(err)
 	}
 }
 
@@ -278,7 +278,7 @@ func (c *Client) transferOverLocalRelay(options TransferOptions, errchan chan<- 
 	conn, banner, ipaddr, err := tcp.ConnectToTCPServer("localhost:"+c.Options.RelayPorts[0], c.Options.RelayPassword, c.Options.SharedSecret[:3])
 	log.Debugf("banner: %s", banner)
 	if err != nil {
-		err = errors.Wrap(err, fmt.Sprintf("could not connect to localhost:%s", c.Options.RelayPorts[0]))
+		err = fmt.Errorf("could not connect to localhost:%s: %w", c.Options.RelayPorts[0], err)
 		log.Debug(err)
 		// not really an error because it will try to connect over the actual relay
 		return
@@ -345,7 +345,7 @@ func (c *Client) Send(options TransferOptions) (err error) {
 		conn, banner, ipaddr, err := tcp.ConnectToTCPServer(c.Options.RelayAddress, c.Options.RelayPassword, c.Options.SharedSecret[:3], 5*time.Second)
 		log.Debugf("banner: %s", banner)
 		if err != nil {
-			err = errors.Wrap(err, fmt.Sprintf("could not connect to %s", c.Options.RelayAddress))
+			err = fmt.Errorf("could not connect to %s: %w", c.Options.RelayAddress, err)
 			log.Debug(err)
 			errchan <- err
 			return
@@ -365,13 +365,15 @@ func (c *Client) Send(options TransferOptions) (err error) {
 					// get list of local ips
 					ips, err = utils.GetLocalIPs()
 					if err != nil {
-						log.Debugf("error getting local ips: %s", err.Error())
+						log.Debugf("error getting local ips: %v", err)
 					}
 					// prepend the port that is being listened to
 					ips = append([]string{c.Options.RelayPorts[0]}, ips...)
 				}
 				bips, _ := json.Marshal(ips)
-				conn.Send(bips)
+				if err := conn.Send(bips); err != nil {
+					log.Errorf("error sending: %v", err)
+				}
 			} else if bytes.Equal(data, []byte("handshake")) {
 				break
 			} else if bytes.Equal(data, []byte{1}) {
@@ -401,7 +403,7 @@ func (c *Client) Send(options TransferOptions) (err error) {
 		// return if no error
 		return
 	} else {
-		log.Debugf("error from errchan: %s", err.Error())
+		log.Debugf("error from errchan: %v", err)
 	}
 	if !c.Options.DisableLocal {
 		if strings.Contains(err.Error(), "refusing files") || strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "bad password") {
@@ -459,7 +461,8 @@ func (c *Client) Receive() (err error) {
 	c.conn[0], banner, c.ExternalIP, err = tcp.ConnectToTCPServer(c.Options.RelayAddress, c.Options.RelayPassword, c.Options.SharedSecret[:3])
 	log.Debugf("banner: %s", banner)
 	if err != nil {
-		err = errors.Wrap(err, fmt.Sprintf("could not connect to %s", c.Options.RelayAddress))
+		err = fmt.Errorf("could not connect to %s: %w", c.Options.RelayAddress, err)
+		log.Debug(err)
 		return
 	}
 	log.Debugf("receiver connection established: %+v", c.conn[0])
@@ -469,14 +472,18 @@ func (c *Client) Receive() (err error) {
 		// and try to connect to them
 		log.Debug("sending ips?")
 		var data []byte
-		c.conn[0].Send([]byte("ips?"))
+		if err := c.conn[0].Send([]byte("ips?")); err != nil {
+			log.Errorf("ips send error: %v", err)
+		}
 		data, err = c.conn[0].Receive()
 		if err != nil {
 			return
 		}
 		log.Debugf("ips data: %s", data)
 		var ips []string
-		json.Unmarshal(data, &ips)
+		if err := json.Unmarshal(data, &ips); err != nil {
+			log.Errorf("ips unmarshal error: %v", err)
+		}
 		if len(ips) > 1 {
 			port := ips[0]
 			ips = ips[1:]
@@ -517,7 +524,9 @@ func (c *Client) Receive() (err error) {
 		}
 	}
 
-	c.conn[0].Send([]byte("handshake"))
+	if err := c.conn[0].Send([]byte("handshake")); err != nil {
+		log.Errorf("handshake send error: %v", err)
+	}
 	c.Options.RelayPorts = strings.Split(banner, ",")
 	if c.Options.NoMultiplexing {
 		log.Debug("no multiplexing")
@@ -552,7 +561,7 @@ func (c *Client) transfer(options TransferOptions) (err error) {
 		var done bool
 		data, err = c.conn[0].Receive()
 		if err != nil {
-			log.Debugf("got error receiving: %s", err.Error())
+			log.Debugf("got error receiving: %v", err)
 			if !c.Step1ChannelSecured {
 				err = fmt.Errorf("could not secure channel")
 			}
@@ -560,7 +569,7 @@ func (c *Client) transfer(options TransferOptions) (err error) {
 		}
 		done, err = c.processMessage(data)
 		if err != nil {
-			log.Debugf("got error processing: %s", err.Error())
+			log.Debugf("got error processing: %v", err)
 			break
 		}
 		if done {
@@ -580,7 +589,9 @@ func (c *Client) transfer(options TransferOptions) (err error) {
 			c.FilesToTransfer[c.FilesToTransferCurrentNum].FolderRemote,
 			c.FilesToTransfer[c.FilesToTransferCurrentNum].Name,
 		)
-		os.Remove(pathToFile)
+		if err := os.Remove(pathToFile); err != nil {
+			log.Warnf("error removing %s: %v", pathToFile, err)
+		}
 	}
 	return
 }
@@ -629,7 +640,7 @@ func (c *Client) processMessageFileInfo(m message.Message) (done bool, err error
 	return
 }
 
-func (c *Client) procesMesssagePake(m message.Message) (err error) {
+func (c *Client) procesMessagePake(m message.Message) (err error) {
 	log.Debug("received pake payload")
 	// if // c.spinner.Suffix != " performing PAKE..." {
 	// 	// c.spinner.Stop()
@@ -651,7 +662,10 @@ func (c *Client) procesMesssagePake(m message.Message) (err error) {
 		if c.Options.IsSender {
 			log.Debug("generating salt")
 			salt := make([]byte, 8)
-			rand.Read(salt)
+			if _, rerr := rand.Read(salt); err != nil {
+				log.Errorf("can't generate random numbers: %v", rerr)
+				return
+			}
 			err = message.Send(c.conn[0], c.Key, message.Message{
 				Type:  "salt",
 				Bytes: salt,
@@ -742,7 +756,8 @@ func (c *Client) processExternalIP(m message.Message) (done bool, err error) {
 func (c *Client) processMessage(payload []byte) (done bool, err error) {
 	m, err := message.Decode(c.Key, payload)
 	if err != nil {
-		err = fmt.Errorf("problem with decoding: %s", err.Error())
+		err = fmt.Errorf("problem with decoding: %w", err)
+		log.Debug(err)
 		return
 	}
 
@@ -755,9 +770,10 @@ func (c *Client) processMessage(payload []byte) (done bool, err error) {
 		c.SuccessfulTransfer = true
 		return
 	case "pake":
-		err = c.procesMesssagePake(m)
+		err = c.procesMessagePake(m)
 		if err != nil {
-			err = errors.Wrap(err, "pake not successful")
+			err = fmt.Errorf("pake not successful: %w", err)
+			log.Debug(err)
 		}
 	case "salt":
 		done, err = c.processMessageSalt(m)
@@ -814,12 +830,12 @@ func (c *Client) processMessage(payload []byte) (done bool, err error) {
 		c.Step3RecipientRequestFile = false
 	}
 	if err != nil {
-		log.Debugf("got error from processing message: %s", err.Error())
+		log.Debugf("got error from processing message: %v", err)
 		return
 	}
 	err = c.updateState()
 	if err != nil {
-		log.Debugf("got error from updating state: %s", err.Error())
+		log.Debugf("got error from updating state: %v", err)
 		return
 	}
 	return
@@ -861,7 +877,9 @@ func (c *Client) recipientInitializeFile() (err error) {
 		c.FilesToTransfer[c.FilesToTransferCurrentNum].Name,
 	)
 	folderForFile, _ := filepath.Split(pathToFile)
-	os.MkdirAll(folderForFile, os.ModePerm)
+	if err := os.MkdirAll(folderForFile, os.ModePerm); err != nil {
+		log.Errorf("can't create %s: %v", folderForFile, err)
+	}
 	var errOpen error
 	c.CurrentFile, errOpen = os.OpenFile(
 		pathToFile,
@@ -884,7 +902,7 @@ func (c *Client) recipientInitializeFile() (err error) {
 	} else {
 		c.CurrentFile, errOpen = os.Create(pathToFile)
 		if errOpen != nil {
-			errOpen = errors.Wrap(errOpen, "could not create "+pathToFile)
+			errOpen = fmt.Errorf("could not create %s: %w", pathToFile, errOpen)
 			log.Error(errOpen)
 			return errOpen
 		}
@@ -893,7 +911,7 @@ func (c *Client) recipientInitializeFile() (err error) {
 	if truncate {
 		err := c.CurrentFile.Truncate(c.FilesToTransfer[c.FilesToTransferCurrentNum].Size)
 		if err != nil {
-			err = errors.Wrap(err, "could not truncate "+pathToFile)
+			err = fmt.Errorf("could not truncate %s: %w", pathToFile, err)
 			log.Error(err)
 			return err
 		}
@@ -1159,7 +1177,9 @@ func (c *Client) receiveData(i int) {
 		c.TotalChunksTransfered++
 		if c.TotalChunksTransfered == len(c.CurrentFileChunks) || c.TotalSent == c.FilesToTransfer[c.FilesToTransferCurrentNum].Size {
 			log.Debug("finished receiving!")
-			c.CurrentFile.Close()
+			if err := c.CurrentFile.Close(); err != nil {
+				log.Errorf("error closing %s: %v", c.CurrentFile.Name(), err)
+			}
 			if c.Options.Stdout || strings.HasPrefix(c.FilesToTransfer[c.FilesToTransferCurrentNum].Name, "croc-stdin") {
 				pathToFile := path.Join(
 					c.FilesToTransfer[c.FilesToTransferCurrentNum].FolderRemote,
@@ -1187,7 +1207,9 @@ func (c *Client) sendData(i int) {
 		c.numfinished++
 		if c.numfinished == len(c.Options.RelayPorts) {
 			log.Debug("closing file")
-			c.fread.Close()
+			if err := c.fread.Close(); err != nil {
+				log.Errorf("error closing file: %v", err)
+			}
 		}
 	}()
 

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -12,8 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
 func init() {
 	log.SetLevel("trace")
+
 	go tcp.Run("debug", "8081", "pass123", "8082,8083,8084,8085")
 	go tcp.Run("debug", "8082", "pass123")
 	go tcp.Run("debug", "8083", "pass123")
@@ -59,14 +66,20 @@ func TestCrocReadme(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		sender.Send(TransferOptions{
+		err := sender.Send(TransferOptions{
 			PathToFiles: []string{"../../README.md"},
 		})
+		if err != nil {
+			t.Errorf("send failed: %v", err)
+		}
 		wg.Done()
 	}()
 	time.Sleep(100 * time.Millisecond)
 	go func() {
-		receiver.Receive()
+		err := receiver.Receive()
+		if err != nil {
+			t.Errorf("receive failed: %v", err)
+		}
 		wg.Done()
 	}()
 
@@ -115,15 +128,21 @@ func TestCrocLocal(t *testing.T) {
 	os.Create("touched")
 	wg.Add(2)
 	go func() {
-		sender.Send(TransferOptions{
+		err := sender.Send(TransferOptions{
 			PathToFiles:      []string{"../../LICENSE", "touched"},
 			KeepPathInRemote: false,
 		})
+		if err != nil {
+			t.Errorf("send failed: %v", err)
+		}
 		wg.Done()
 	}()
 	time.Sleep(100 * time.Millisecond)
 	go func() {
-		receiver.Receive()
+		err := receiver.Receive()
+		if err != nil {
+			t.Errorf("send failed: %v", err)
+		}
 		wg.Done()
 	}()
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -125,7 +125,7 @@ func LocalIP() string {
 
 // GetRandomName returns mnemoicoded random name
 func GetRandomName() string {
-	result := []string{}
+	var result []string
 	bs := make([]byte, 4)
 	rand.Read(bs)
 	result = mnemonicode.EncodeWordList(result, bs)
@@ -157,7 +157,7 @@ func MissingChunks(fname string, fsize int64, chunkSize int) (chunkRanges []int6
 	defer f.Close()
 
 	fstat, err := os.Stat(fname)
-	if fstat.Size() != fsize || err != nil {
+	if err != nil || fstat.Size() != fsize {
 		return
 	}
 

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -165,14 +165,14 @@ func TestHashFile(t *testing.T) {
 func TestPublicIP(t *testing.T) {
 	ip, err := PublicIP()
 	fmt.Println(ip)
-	assert.True(t, strings.Contains(ip, "."))
+	assert.True(t, strings.Contains(ip, ".") || strings.Contains(ip, ":"))
 	assert.Nil(t, err)
 }
 
 func TestLocalIP(t *testing.T) {
 	ip := LocalIP()
 	fmt.Println(ip)
-	assert.True(t, strings.Contains(ip, "."))
+	assert.True(t, strings.Contains(ip, ".") || strings.Contains(ip, ":"))
 }
 
 func TestGetRandomName(t *testing.T) {


### PR DESCRIPTION
While I had the code checked out I decided to do some minor style cleanups and improve the error reporting.

Two tiny bugs. This is unsafe:

```
  fstat, err := os.Stat(fname)
  if fstat.Size() != fsize || err != nil {
    return
  }
```

You should check err != nil first before using the value of fstat:

    if err != nil || fstat.Size() != fsize {

The if statement will evaluate subexpressions of the same precedence from left to right.

Bug two, the unit tests were failing on dual-stack (IPv6) systems.

On to the stylistic changes...

When reporting errors, in current versions of Go

    log.Errorf("...%s", err.Error())

can be replaced with the shorter

    log.Errorf("...%v", err)

which will do the right thing, and `x/errors.Wrap` can be replaced with stdlib `fmt.Errorf`'s new `%w` error-wrapping directive, so I did that too. ref: [Go 1.13 error handling updates](https://blog.golang.org/go1.13-errors)

I mostly didn't add error checking for file close operations, with the exception of the close after successfully receiving a file. For that file close, you really want to know if (for example) the file couldn't be closed because the OS tried to flush the write buffer and failed, meaning the file is probably corrupt.

Finally, all wrapped errors should now include the actual underlying error in their message.