### PR TITLE
Add Termux installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ On Ubuntu you can install with `snap`:
 $ snap install croc
 ```
 
+On Termux you can install with `pkg`:
+
+```
+$ pkg install croc
+```
+
 Or, you can [install Go](https://golang.org/dl/) and build from source (requires Go 1.12+): 
 
 ```


### PR DESCRIPTION
I added croc package (termux/termux-packages#5779) for [Termux](https://termux.com), so let's mention this in README for others.