### PR TITLE
Add environment variables to CLI

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -80,10 +80,10 @@ func Run() (err error) {
 		&cli.BoolFlag{Name: "stdout", Usage: "redirect file to stdout"},
 		&cli.BoolFlag{Name: "no-compress", Usage: "disable compression"},
 		&cli.BoolFlag{Name: "ask", Usage: "make sure sender and recipient are prompted"},
-		&cli.StringFlag{Name: "relay", Value: models.DEFAULT_RELAY, Usage: "address of the relay"},
-		&cli.StringFlag{Name: "relay6", Value: models.DEFAULT_RELAY6, Usage: "ipv6 address of the relay"},
+		&cli.StringFlag{Name: "relay", Value: models.DEFAULT_RELAY, Usage: "address of the relay", EnvVars: []string{"CROC_RELAY"}},
+		&cli.StringFlag{Name: "relay6", Value: models.DEFAULT_RELAY6, Usage: "ipv6 address of the relay", EnvVars: []string{"CROC_RELAY6"}},
 		&cli.StringFlag{Name: "out", Value: ".", Usage: "specify an output folder to receive the file"},
-		&cli.StringFlag{Name: "pass", Value: "pass123", Usage: "password for the relay"},
+		&cli.StringFlag{Name: "pass", Value: "pass123", Usage: "password for the relay", EnvVars: []string{"CROC_PASS"}},
 	}
 	app.EnableBashCompletion = true
 	app.HideHelp = false


### PR DESCRIPTION
This PR allows a user to set environment variables for a few of the CLI options that could be considered security measures.

Let me know if you'd like me to add/rename any, as this only covers `relay`, `relay6`, and `pass` options.

I should mention I am aware of the `--remember` flag, but I figured this might be nice to avoid passwords in a plain-text file etc.