### PR TITLE
Add error reporting

### DIFF
--- a/src/compress/compress.go
+++ b/src/compress/compress.go
@@ -32,7 +32,10 @@ func Decompress(src []byte) []byte {
 
 // compress uses flate to compress a byte slice to a corresponding level
 func compress(src []byte, dest io.Writer, level int) {
-	compressor, _ := flate.NewWriter(dest, level)
+	compressor, err := flate.NewWriter(dest, level)
+	if err != nil {
+		log.Debugf("error level data: %v", err)
+	}
 	if _, err := compressor.Write(src); err != nil {
 		log.Debugf("error writing data: %v", err)
 	}


### PR DESCRIPTION
flate.NewWriter(w io.Writer, level int) (*Writer, error)
If level is not in the range [-2, 9] then the error returned will be non-nil.