### PR TITLE
Show all files when sending without send command

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -89,10 +89,23 @@ func Run() (err error) {
 	app.HideHelp = false
 	app.HideVersion = false
 	app.Action = func(c *cli.Context) error {
+		allStringsAreFiles := func(strs []string) bool {
+			for _, str := range strs {
+				if !utils.Exists(str) {
+					return false;
+				}
+			}
+			return true;
+		}
+
 		// if trying to send but forgot send, let the user know
-		if c.Args().First() != "" && utils.Exists(c.Args().First()) {
-			_, fname := filepath.Split(c.Args().First())
-			yn := utils.GetInput(fmt.Sprintf("Did you mean to send '%s'? (y/n) ", fname))
+		if c.Args().Present() && allStringsAreFiles(c.Args().Slice()) {
+			fnames := []string{}
+			for _, fpath := range c.Args().Slice() {
+				_, basename := filepath.Split(fpath)
+				fnames = append(fnames, "'" + basename + "'")
+			}
+			yn := utils.GetInput(fmt.Sprintf("Did you mean to send %s? (y/n) ", strings.Join(fnames, ", ")))
 			if strings.ToLower(yn) == "y" {
 				return send(c)
 			}


### PR DESCRIPTION
This PR is a possible fix for #264:

> When sending files without the send argument (e.g. drag and drop multiple files into croc) it only shows the first file in the confirmation dialog.

Through the discussion in the issue it turned out that croc always supported sending multiple files without "send" argument, but neither the code nor the message shown to the user reflects that. With the PR changeset, it is first checked that all passed arguments are indeed files/folders (not only the first one), and If they are, all of them are displayed to the user (not only the first one).

Example in master branch:
```
$ ./croc README.md Dockerfile src/croc/croc.go
Did you mean to send 'README.md'? (y/n)
```

Example in PR branch:
```
$ ./croc README.md Dockerfile src/croc/croc.go
Did you mean to send 'README.md', 'Dockerfile', 'croc.go'? (y/n)
```

Note that I'm a golang noob and the code can be very likely written in a more elegant way. Any feedback would be greatly appreciated!
Also I'm not sure If it's worth the additional LOC for a feature that is not even within the correct usage but rather a convenience feature. But in any case it made me study golang a bit and get to know new usage details about croc.

Great tool by the way!