### PR TITLE
fix send without argument (trigger intended error message)

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -232,7 +232,7 @@ func send(c *cli.Context) (err error) {
 		}()
 
 	} else {
-		fnames = append([]string{c.Args().First()}, c.Args().Tail()...)
+		fnames = c.Args().Slice()
 	}
 	if len(fnames) == 0 {
 		return errors.New("must specify file: croc send [filename]")


### PR DESCRIPTION
In the `send()` function of the CLI module there is an error handler for the case that no further argument for the `send` command has been provided:
```
if len(fnames) == 0 {
    return errors.New("must specify file: croc send [filename]")
}
```
Unfortunately, due to the way fnames is currently constructed from c.Args(), its length is never below 1 and hence the message never shows up. The PR fixes this.

On master branch:
```
$ ./croc send
stat : no such file or directory
```

On PR branch:
```
$ ./croc send
must specify file: croc send [filename]
```