### PR TITLE
README: Add install instructions for gentoo via portage

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ On Ubuntu you can install with `snap`:
 $ snap install croc
 ```
 
+On Gentoo you can install with `portage`:
+```
+$ emerge net-misc/croc
+```
+
 On Termux you can install with `pkg`:
 
 ```


### PR DESCRIPTION
Since today, croc is available in official gentoo portage.
See: https://bugs.gentoo.org/743460

* Updated README with gentoo instructions