### PR TITLE
fix(cli): show passphrase when user indicate --pass

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -88,7 +88,7 @@ func Run() (err error) {
 		&cli.StringFlag{Name: "relay", Value: models.DEFAULT_RELAY, Usage: "address of the relay", EnvVars: []string{"CROC_RELAY"}},
 		&cli.StringFlag{Name: "relay6", Value: models.DEFAULT_RELAY6, Usage: "ipv6 address of the relay", EnvVars: []string{"CROC_RELAY6"}},
 		&cli.StringFlag{Name: "out", Value: ".", Usage: "specify an output folder to receive the file"},
-		&cli.StringFlag{Name: "pass", Value: "pass123", Usage: "password for the relay", EnvVars: []string{"CROC_PASS"}},
+		&cli.StringFlag{Name: "pass", Value: models.DEFAULT_PASSPHRASE, Usage: "password for the relay", EnvVars: []string{"CROC_PASS"}},
 		&cli.StringFlag{Name: "socks5", Value: "", Usage: "add a socks5 proxy", EnvVars: []string{"SOCKS5_PROXY"}},
 	}
 	app.EnableBashCompletion = true

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -347,17 +347,14 @@ func (c *Client) Send(options TransferOptions) (err error) {
 	if err != nil {
 		return
 	}
-	var (
-		otherRelay      string
-		otherPassphrase string
-	)
+	flags := &strings.Builder{}
 	if c.Options.RelayAddress != models.DEFAULT_RELAY {
-		otherRelay = "--relay " + c.Options.RelayAddress + " "
+		flags.WriteString("--relay " + c.Options.RelayAddress + " ")
 	}
 	if c.Options.RelayPassword != models.DEFAULT_PASSPHRASE {
-		otherPassphrase = "--pass " + c.Options.RelayPassword + " "
+		flags.WriteString("--pass " + c.Options.RelayPassword + " ")
 	}
-	fmt.Fprintf(os.Stderr, "Code is: %s\nOn the other computer run\n\ncroc %s%s%s\n", c.Options.SharedSecret, otherPassphrase, otherRelay, c.Options.SharedSecret)
+	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\n\ncroc %[2]s%[1]s\n", c.Options.SharedSecret, flags.String())
 	if c.Options.Ask {
 		machid, _ := machineid.ID()
 		fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -347,11 +347,17 @@ func (c *Client) Send(options TransferOptions) (err error) {
 	if err != nil {
 		return
 	}
-	otherRelay := ""
+	var (
+		otherRelay      string
+		otherPassphrase string
+	)
 	if c.Options.RelayAddress != models.DEFAULT_RELAY {
 		otherRelay = "--relay " + c.Options.RelayAddress + " "
 	}
-	fmt.Fprintf(os.Stderr, "Code is: %s\nOn the other computer run\n\ncroc %s%s\n", c.Options.SharedSecret, otherRelay, c.Options.SharedSecret)
+	if c.Options.RelayPassword != models.DEFAULT_PASSPHRASE {
+		otherPassphrase = "--pass " + c.Options.RelayPassword + " "
+	}
+	fmt.Fprintf(os.Stderr, "Code is: %s\nOn the other computer run\n\ncroc %s%s%s\n", c.Options.SharedSecret, otherPassphrase, otherRelay, c.Options.SharedSecret)
 	if c.Options.Ask {
 		machid, _ := machineid.ID()
 		fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)

--- a/src/models/constants.go
+++ b/src/models/constants.go
@@ -6,9 +6,12 @@ import "net"
 const TCP_BUFFER_SIZE = 1024 * 64
 
 // DEFAULT_RELAY is the default relay used (can be set using --relay)
-var DEFAULT_RELAY = "croc.schollz.com"
-var DEFAULT_RELAY6 = "croc6.schollz.com"
-var DEFAULT_PORT = "9009"
+var (
+	DEFAULT_RELAY      = "croc.schollz.com"
+	DEFAULT_RELAY6     = "croc6.schollz.com"
+	DEFAULT_PORT       = "9009"
+	DEFAULT_PASSPHRASE = "pass123"
+)
 
 func init() {
 	iprecords, _ := net.LookupIP(DEFAULT_RELAY)


### PR DESCRIPTION
Hi @schollz ,

This PR is to fix the bug described in #291 , please take a look.

changes:
+ use constant for default passphrase.
+ when pass is different from passphrase, show `--pass` flag in recommended receive command.