### PR TITLE
Harden systemd service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ Or, you can [install Go](https://golang.org/dl/) and build from source (requires
 $ GO111MODULE=on go get -v github.com/schollz/croc/v8
 ```
 
-
-
 ## Usage 
 
 To send a file, simply do: 
@@ -183,6 +181,16 @@ $ croc --relay "myrelay.example.com:9009" send [filename]
 ```
 
 Note, when sending, you only need to include the first port (the communication port). The subsequent ports for data transfer will be transmitted back to the user from the relay.
+
+For systems that use systemd you can use the included service file to run croc automatically and with reduced system privileges.
+
+* Save the `croc.service` file to `/etc/systemd/system`.
+* Edit the `Environment="CROC_PASS...` line according to your relay password.
+* If your croc binary is located in a path other than `/usr/local/bin` you will need to amend the `ExecPath`, `TemporaryFileSystem` and `BindReadOnlyPaths` directives accordingly.
+* Amend the `User` and `Group` directives to reflect the system account that your relay uses.
+* Issue `# systemctl daemon-reload` after any changes to the service file.
+* Issue `# systemctl enable --now croc` to enable automatic start and to start the relay.
+* `$ journalctl -u croc` will list any problems starting the service and `$ systemctl status croc` will display the current state of the relay.
 
 #### Self-host relay (docker)
 

--- a/croc.service
+++ b/croc.service
@@ -11,8 +11,7 @@ Type=simple
 User=croc-relay
 Group=nogroup
 
-InaccessiblePaths=/bin /boot /etc /home /lib /lost+found /media /mnt /opt /root /sbin /srv /var
-
+# Hardening
 TemporaryFileSystem=/usr:ro
 BindReadOnlyPaths=/usr/local/bin/croc
 
@@ -22,16 +21,17 @@ KeyringMode=private
 LockPersonality=true
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+PrivateUsers=true
 ProtectClock=true
 ProtectControlGroups=true
 ProtectHome=true
 ProtectHostname=true
-ProtectKernelModules=true
 ProtectKernelLogs=true
+ProtectKernelModules=true
 ProtectKernelTunables=true
 ProtectSystem=strict
-PrivateDevices=true
-PrivateTmp=true
 RemoveIPC=true
 RestrictAddressFamilies=AF_INET AF_INET6
 RestrictNamespaces=true
@@ -42,8 +42,14 @@ RestrictSUIDSGID=true
 # Other bits are both set and locked.
 SecureBits=keepcaps-locked,noroot,noroot-locked,no-suid-fixup,no-suid-fixup-locked
 SystemCallArchitectures=native
-# List of permitted syscalls; any others will result in termination via SIGSYS.
+# List of permitted syscalls
 SystemCallFilter=@network-io @system-service
+# List of denied syscalls (inherited from @system-service)
+SystemCallFilter=~@privileged ~@resources
+
+# At time of writing, no available systems to test these directives.
+#ProtectProc=noaccess
+#ProcSubset=all
 
 [Install]
 WantedBy=multi-user.target

--- a/croc.service
+++ b/croc.service
@@ -1,12 +1,49 @@
 [Unit]
-Description=croc relay
+Description=croc relay service
 After=network.target
 
 [Service]
+Environment="CROC_PASS=pass123"
+ExecStart=/usr/local/bin/croc relay
+Restart=always
+RestartSec=60
 Type=simple
-User=nobody
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-ExecStart=/usr/bin/croc relay
+User=croc-relay
+Group=nogroup
+
+InaccessiblePaths=/bin /boot /etc /home /lib /lost+found /media /mnt /opt /root /sbin /srv /var
+
+TemporaryFileSystem=/usr:ro
+BindReadOnlyPaths=/usr/local/bin/croc
+
+# A null CapabilityBoundingSet sets the service to have no capabilities.
+CapabilityBoundingSet=
+KeyringMode=private
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+PrivateDevices=true
+PrivateTmp=true
+RemoveIPC=true
+RestrictAddressFamilies=AF_INET AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+# SECBIT_KEEP_CAPS defaults to "off", which is preferred for security.
+# Hence for this bit, we only lock it, without also setting it. 
+# Other bits are both set and locked.
+SecureBits=keepcaps-locked,noroot,noroot-locked,no-suid-fixup,no-suid-fixup-locked
+SystemCallArchitectures=native
+# List of permitted syscalls; any others will result in termination via SIGSYS.
+SystemCallFilter=@network-io @system-service
 
 [Install]
 WantedBy=multi-user.target

--- a/croc.service
+++ b/croc.service
@@ -43,7 +43,7 @@ RestrictSUIDSGID=true
 SecureBits=keepcaps-locked,noroot,noroot-locked,no-suid-fixup,no-suid-fixup-locked
 SystemCallArchitectures=native
 # List of permitted syscalls
-SystemCallFilter=@network-io @system-service
+SystemCallFilter=@system-service
 # List of denied syscalls (inherited from @system-service)
 SystemCallFilter=~@privileged ~@resources
 


### PR DESCRIPTION
I tend to err on the side of paranoia and am running a relay on Raspian with a lot of systemd hardening directives and it works a treat. This prevents croc from writing to the file system, only reading the binary itself and restricts many other actions that a well-behaved croc will not be trying to do. Not all of these directives are supported depending on your version of systemd (e.g. by Raspbian) but systemd skips any it doesn't recognise.

I added placeholder for CROC_PASS envvar as I assume users will be using a password; assume running as a system user "croc-relay" with no group; assume installation to /usr/local/bin (as per the croc installer script); and remove CAP_NET_BIND_SERVICE as it's only necessary for binding to ports <1024 which I would expect is not how folk would use the relay.

I haven't had a chance to try these hardening directives on other systems or flavours so please keep that in mind.