### PR TITLE
Issue #306, File Size Mismatch

### DIFF
--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -136,7 +136,7 @@ func GetRandomName() string {
 
 // ByteCountDecimal converts bytes to human readable byte string
 func ByteCountDecimal(b int64) string {
-	const unit = 1000
+	const unit = 1024
 	if b < unit {
 		return fmt.Sprintf("%d B", b)
 	}

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -88,9 +88,9 @@ func TestSHA256(t *testing.T) {
 }
 
 func TestByteCountDecimal(t *testing.T) {
-	assert.Equal(t, "10.0 kB", ByteCountDecimal(10000))
+	assert.Equal(t, "10.0 kB", ByteCountDecimal(10240))
 	assert.Equal(t, "50 B", ByteCountDecimal(50))
-	assert.Equal(t, "12.4 MB", ByteCountDecimal(12378517))
+	assert.Equal(t, "12.4 MB", ByteCountDecimal(13002343))
 }
 
 func TestMissingChunks(t *testing.T) {


### PR DESCRIPTION
**Should be tested before merging**
I'm not setup to compile or run Go projects, so I'm not able to test this myself.

- Updated utils.go to use a `1024` grouping instead of `1000` for file
sizes. This brings it inline with the progress bar project being used.
- Updated utils_test.go to match the changes to utils.go