### PR TITLE
Added an option to ignore attached stdin.

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -85,6 +85,7 @@ func Run() (err error) {
 		&cli.BoolFlag{Name: "no-compress", Usage: "disable compression"},
 		&cli.BoolFlag{Name: "ask", Usage: "make sure sender and recipient are prompted"},
 		&cli.BoolFlag{Name: "local", Usage: "force to use only local connections"},
+		&cli.BoolFlag{Name: "ignoreStdin", Usage: "ignore piped stdin"},
 		&cli.StringFlag{Name: "ip", Value: "", Usage: "set sender ip if known e.g. 10.0.0.1:9009, [::1]:9009"},
 		&cli.StringFlag{Name: "relay", Value: models.DEFAULT_RELAY, Usage: "address of the relay", EnvVars: []string{"CROC_RELAY"}},
 		&cli.StringFlag{Name: "relay6", Value: models.DEFAULT_RELAY6, Usage: "ipv6 address of the relay", EnvVars: []string{"CROC_RELAY6"}},
@@ -177,6 +178,7 @@ func send(c *cli.Context) (err error) {
 		Stdout:         c.Bool("stdout"),
 		DisableLocal:   c.Bool("no-local"),
 		OnlyLocal:      c.Bool("local"),
+		IgnoreStdin:	c.Bool("ignoreStdin"),
 		RelayPorts:     strings.Split(c.String("ports"), ","),
 		Ask:            c.Bool("ask"),
 		NoMultiplexing: c.Bool("no-multi"),
@@ -217,7 +219,7 @@ func send(c *cli.Context) (err error) {
 
 	var fnames []string
 	stat, _ := os.Stdin.Stat()
-	if (stat.Mode() & os.ModeCharDevice) == 0 {
+	if ((stat.Mode() & os.ModeCharDevice) == 0) && !c.Bool("ignoreStdin") {
 		fnames, err = getStdin()
 		if err != nil {
 			return

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -61,6 +61,7 @@ type Options struct {
 	NoMultiplexing bool
 	DisableLocal   bool
 	OnlyLocal      bool
+	IgnoreStdin    bool
 	Ask            bool
 	SendingText    bool
 	NoCompress     bool


### PR DESCRIPTION
This is to allow croc to run as a Node.js child process, as you can't stop Node piping stdio (even if you set it not to, it still pipes to /dev/null).
These changes are very helpful to me, but no worries if they don't fit the project in general.