### PR TITLE
Docker deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm,linux/arm64,linux/386,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm,linux/arm64,linux/386,linux/ppc64le
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CD
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: schollz/croc
+          # tag-semver: "{{version}}"
+          tag-sha: true
+          tag-latest: true
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm,linux/arm64,linux/386,linux/ppc64le,linux/s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm,linux/arm64,linux/386,linux/ppc64le
+          platforms: linux/amd64,linux/arm,linux/arm64,linux/386
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
Adds a GitHub action that deploys to Docker Hub. This fixes #317.

Unfortunately, not all linux platforms worked, so I had to remove the ones that didn't. I tested it [my gh-actions branch](https://github.com/Spaceface16518/croc/commits/gh-actions) and cherry-picked the needed patches into this PR.

I tried to stick as close as I could to your responses in #317, but there were some caveats.

- Adding branches to `on.push.branches` will cause deployments tagged with the branch name.
- You can't automatically tag deployments as `latest` without deploying on release. You can do this by adding `tags: v*` to `on` and uncommenting line 29 (`tag-semver: "{{version}}"`).  

     > Push to master should trigger

    While you specifically objected to this, I strongly suggesting adding release tagging (as well as other semver tags) because it helps tie deployments to a major or minor version of croc instead of just `latest`. Specifically, doing this would add shared tags like `schollz/croc:8.6.7` (and optionally `schollz/croc:8.6` and `schollz/croc:8`), allowing automatic tagging of `schollz/croc:latest`. There _are_ ways to get around this limitation, but I suggest tagging versions instead. Please request changes in a review if you would like me to implement release tagging.

While developing this PR, I deployed [a test image](https://hub.docker.com/r/spaceface16518/croc/) that you can look at for an example of what it will look like.

**IMPORTANT: You will need to add two secrets to the repository, your docker hub username and password, `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`, respectively.** It would be advantageous to add these secrets before merging the PR, so that the deployment works right away. If not, you can always restart the job.