### PR TITLE
Reduce size of Docker image by stripping debug symbols

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.15-alpine as builder
 RUN apk add --no-cache git
 WORKDIR /go/croc
 COPY . .
-RUN go build -v
+RUN go build -v -ldflags="-s -w"
 
 FROM alpine:latest 
 EXPOSE 9009


### PR DESCRIPTION
Using the [`-s` and `-w` linker flags](https://golang.org/cmd/link/) reduces the size of the program files added to the by about 29% (8.32MB → 5.94MB) by omitting "the symbol table and debug information," and omitting "the DWARF symbol table," respectively.

This is already being done during the release process.

https://github.com/schollz/croc/blob/493eb075f16a7c92e2b60328750cbf810a2acf29/goreleaser.yml#L5

However, this opportunity is being missed during the Docker build process. This change decreases the overall image size by about 17% (13.9MB → 11.5MB).