### PR TITLE
fix(cli): make 'code too short' error symmetric on both sender and receiver side

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ package main
 //go:generate git tag -af v$VERSION -m "v$VERSION"
 
 import (
-	"fmt"
+	"log"
 
 	"github.com/schollz/croc/v8/src/cli"
 )
@@ -28,6 +28,6 @@ func main() {
 	// 	}
 	// }()
 	if err := cli.Run(); err != nil {
-		fmt.Println(err)
+		log.Fatalln(err)
 	}
 }

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -223,9 +223,9 @@ func send(c *cli.Context) (err error) {
 			return
 		}
 		defer func() {
-			err = os.Remove(fnames[0])
-			if err != nil {
-				log.Error(err)
+			e := os.Remove(fnames[0])
+			if e != nil {
+				log.Error(e)
 			}
 		}()
 	} else if c.String("text") != "" {
@@ -234,9 +234,9 @@ func send(c *cli.Context) (err error) {
 			return
 		}
 		defer func() {
-			err = os.Remove(fnames[0])
-			if err != nil {
-				log.Error(err)
+			e := os.Remove(fnames[0])
+			if e != nil {
+				log.Error(e)
 			}
 		}()
 


### PR DESCRIPTION
Hi @schollz,

This PR is to fix the bug described in #296.

### Proposed changes:

- Fix missing error on server side when a given code is too short
- In case of an error we now write into _stderr_ and return an _exit code 1_ instead of writing into _stdout_ and returning _exit code 0_
