### PR TITLE
feat: allow providing a custom --maxbytes param for a relay server

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -80,6 +80,7 @@ func Run() (err error) {
 			Flags: []cli.Flag{
 				&cli.StringFlag{Name: "host", Usage: "host of the relay"},
 				&cli.StringFlag{Name: "ports", Value: "9009,9010,9011,9012,9013", Usage: "ports of the relay"},
+				&cli.IntFlag{Name: "maxbytes", Value: comm.MaxBytes, Usage: "maximum bytes which can be relayed"},
 			},
 		},
 	}
@@ -463,6 +464,8 @@ func relay(c *cli.Context) (err error) {
 		debugString = "debug"
 	}
 	host := c.String("host")
+	comm.MaxBytes = c.Int("maxbytes")
+	log.Debugf("setting the maxbytes allowed for relay as %d", comm.MaxBytes)
 	ports := strings.Split(c.String("ports"), ",")
 	tcpPorts := strings.Join(ports[1:], ",")
 	for i, port := range ports {

--- a/src/comm/comm.go
+++ b/src/comm/comm.go
@@ -18,6 +18,7 @@ import (
 var Socks5Proxy = ""
 
 var MAGIC_BYTES = []byte("croc")
+var MaxBytes = 4000000
 
 // Comm is some basic TCP communication
 type Comm struct {
@@ -150,6 +151,11 @@ func (c *Comm) Read() (buf []byte, numBytes int, bs []byte, err error) {
 		return
 	}
 	numBytes = int(numBytesUint32)
+	if numBytes > MaxBytes {
+		err = fmt.Errorf("too many bytes: %d", numBytes)
+		log.Debug(err)
+		return
+	}
 
 	// shorten the reading deadline in case getting weird data
 	if err := c.connection.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {

--- a/src/comm/comm_test.go
+++ b/src/comm/comm_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestComm(t *testing.T) {
-	token := make([]byte, 3000)
+	token := make([]byte, MaxBytes)
 	if _, err := rand.Read(token); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Related to #231 

making the `MAXBYTES` customizable helps to run relay servers
which can allow an arbitary amount of max bytes. By default, the
`MaxBytes` will be set to 40000.

To set a custom MaxBytes variable value:
```bash
croc relay --maxbytes 10000000
```