### PR TITLE
Add compliance with XDG Base Directory Specification (XDG_CONFIG_HOME)

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -131,6 +131,9 @@ func getConfigDir() (homedir string, err error) {
 		return
 	}
 	homedir = path.Join(homedir, ".config", "croc")
+	if xdgConfigHome, isSet := os.LookupEnv("XDG_CONFIG_HOME"); isSet {
+		homedir = path.Join(xdgConfigHome, "croc")
+	}
 	if _, err = os.Stat(homedir); os.IsNotExist(err) {
 		log.Debugf("creating home directory %s", homedir)
 		err = os.MkdirAll(homedir, 0700)


### PR DESCRIPTION
This PR addresses issue #332. 

With this PR `croc` will try to use the configuration directory set by environment variable XDG_CONFIG_HOME. If XDG_CONFIG_HOME is not set it will default to `~/.config` (previous behaviour) according to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables). 