### PR TITLE
misuse of decrypt "bad password"

### DIFF
--- a/src/tcp/tcp.go
+++ b/src/tcp/tcp.go
@@ -208,7 +208,10 @@ func (s *server) clientCommunication(port string, c *comm.Comm) (room string, er
 	}
 	if strings.TrimSpace(string(passwordBytes)) != s.password {
 		err = fmt.Errorf("bad password")
-		enc, _ := crypt.Decrypt([]byte(err.Error()), strongKeyForEncryption)
+		enc, enc_err := crypt.Encrypt([]byte(err.Error()), strongKeyForEncryption)
+		if enc_err != nil {
+			return "", enc_err
+		}
 		if err := c.Send(enc); err != nil {
 			return "", fmt.Errorf("send error: %w", err)
 		}


### PR DESCRIPTION
Sender not receiving the "bad password" message while using a wrong password.

Misuse of `crypt.Decrypt` the "bad password". Actually it return the error but not checked.