### PR TITLE
Remove dollar icons from commands without output

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,74 +37,74 @@ For more information about `croc`, see [my blog post](https://schollz.com/softwa
 Download [the latest release for your system](https://github.com/schollz/croc/releases/latest), or install a release from the command-line:
 
 ```
-$ curl https://getcroc.schollz.com | bash
+curl https://getcroc.schollz.com | bash
 ```
 
 
 On macOS you can install the latest release with [Homebrew](https://brew.sh/): 
 
 ```
-$ brew install croc
+brew install croc
 ```
 
 On macOS you can also install the latest release with [MacPorts](https://macports.org/): 
 
 ```
-$ sudo port selfupdate
-$ sudo port install croc
+sudo port selfupdate
+sudo port install croc
 ```
 
 On Windows you can install the latest release with [Scoop](https://scoop.sh/) or [Chocolatey](https://chocolatey.org): 
 
 ```
-$ scoop install croc
+scoop install croc
 ```
 
 ```
-$ choco install croc
+choco install croc
 ```
 
 On Unix you can install the latest release with [Nix](https://nixos.org/nix):
 
 ```
-$ nix-env -i croc
+nix-env -i croc
 ```
 
 
 On Alpine Linux you have to install dependencies first:
 
 ```
-$ apk add bash coreutils
-$ wget -qO- https://getcroc.schollz.com | bash
+apk add bash coreutils
+wget -qO- https://getcroc.schollz.com | bash
 ```
 
 On Arch Linux you can install the latest release with `pacman`:
 
 ```
-$ pacman -S croc
+pacman -S croc
 ```
 
 On Gentoo you can install with `portage`:
 ```
-$ emerge net-misc/croc
+emerge net-misc/croc
 ```
 
 On Termux you can install with `pkg`:
 
 ```
-$ pkg install croc
+pkg install croc
 ```
 
 On FreeBSD you can install with `pkg`:
 
 ```
-$ pkg install croc
+pkg install croc
 ```
 
 Or, you can [install Go](https://golang.org/dl/) and build from source (requires Go 1.12+): 
 
 ```
-$ GO111MODULE=on go get -v github.com/schollz/croc/v8
+GO111MODULE=on go get -v github.com/schollz/croc/v8
 ```
 
 
@@ -122,7 +122,7 @@ Code is: code-phrase
 Then to receive the file (or folder) on another computer, you can just do 
 
 ```
-$ croc code-phrase
+croc code-phrase
 ```
 
 The code phrase is used to establish password-authenticated key agreement ([PAKE](https://en.wikipedia.org/wiki/Password-authenticated_key_agreement)) which generates a secret key for the sender and recipient to use for end-to-end encryption.
@@ -134,7 +134,7 @@ There are a number of configurable options (see `--help`). A set of options (lik
 You can send with your own code phrase (must be more than 4 characters).
 
 ```
-$ croc send --code [code-phrase] [file(s)-or-folder]
+croc send --code [code-phrase] [file(s)-or-folder]
 ```
 
 ### Use pipes - stdin and stdout
@@ -142,13 +142,13 @@ $ croc send --code [code-phrase] [file(s)-or-folder]
 You can pipe to `croc`:
 
 ```
-$ cat [filename] | croc send
+cat [filename] | croc send
 ```
 
 In this case `croc` will automatically use the stdin data and send and assign a filename like "croc-stdin-123456789". To receive to `stdout` at you can always just use the `--yes`  will automatically approve the transfer and pipe it out to `stdout`. 
 
 ```
-$ croc --yes [code-phrase] > out
+croc --yes [code-phrase] > out
 ```
 
 All of the other text printed to the console is going to `stderr` so it will not interfere with the message going to `stdout`.
@@ -159,7 +159,7 @@ All of the other text printed to the console is going to `stderr` so it will not
 Sometimes you want to send URLs or short text. In addition to piping, you can easily send text with `croc`:
 
 ```
-$ croc send --text "hello world"
+croc send --text "hello world"
 ```
 
 This will automatically tell the receiver to use `stdout` when they receive the text so it will be displayed.
@@ -170,7 +170,7 @@ This will automatically tell the receiver to use `stdout` when they receive the 
 You can use a proxy as your connection to the relay by adding a proxy address with `--socks5`. For example, you can send via a tor relay:
 
 ```
-$ croc --socks5 "127.0.0.1:9050" send SOMEFILE
+croc --socks5 "127.0.0.1:9050" send SOMEFILE
 ```
 
 ### Self-host relay
@@ -178,7 +178,7 @@ $ croc --socks5 "127.0.0.1:9050" send SOMEFILE
 The relay is needed to staple the parallel incoming and outgoing connections. By default, `croc` uses a public relay but you can also run your own relay:
 
 ```
-$ croc relay
+croc relay
 ```
 
 By default it uses TCP ports 9009-9013. Make sure to open those up. You can customized the ports (e.g. `croc relay --ports 1111,1112`), but you must have a minimum of **2** ports for the relay. The first port is for communication and the subsequent ports are used for the multiplexed data transfer.
@@ -186,7 +186,7 @@ By default it uses TCP ports 9009-9013. Make sure to open those up. You can cust
 You can send files using your relay by entering `--relay` to change the relay that you are using if you want to custom host your own.
 
 ```
-$ croc --relay "myrelay.example.com:9009" send [filename]
+croc --relay "myrelay.example.com:9009" send [filename]
 ```
 
 Note, when sending, you only need to include the first port (the communication port). The subsequent ports for data transfer will be transmitted back to the user from the relay.
@@ -197,13 +197,13 @@ If it's easier you can also run a relay with Docker:
 
 
 ```
-$ docker run -d -p 9009-9013:9009-9013 -e CROC_PASS='YOURPASSWORD' schollz/croc
+docker run -d -p 9009-9013:9009-9013 -e CROC_PASS='YOURPASSWORD' schollz/croc
 ```
 
 Be sure to include the password for the relay otherwise any requests will be rejected. 
 
 ```
-$ croc --pass YOURPASSWORD --relay "myreal.example.com:9009" send [filename]
+croc --pass YOURPASSWORD --relay "myreal.example.com:9009" send [filename]
 ```
 
 Note: when including `--pass YOURPASSWORD` you can instead pass a file with the password, e.g. `--pass FILEWITHPASSWORD`.


### PR DESCRIPTION
This will make it easier to copy & paste commands. More information: https://cirosantilli.com/markdown-style-guide/#dollar-signs-in-shell-code