### PR TITLE
Transfer symlinks without touching their targets.

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -324,7 +324,7 @@ func getPaths(fnames []string) (paths []string, haveFolder bool, err error) {
 	haveFolder = false
 	paths = []string{}
 	for _, fname := range fnames {
-		stat, errStat := os.Stat(fname)
+		stat, errStat := os.Lstat(fname)
 		if errStat != nil {
 			err = errStat
 			return

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -41,8 +41,23 @@ func GetInput(prompt string) string {
 	return strings.TrimSpace(text)
 }
 
+// HashFile returns the hash of a file or, in case of a symlink, the
+// SHA256 hash of its target
 // HashFile returns the hash of a file
 func HashFile(fname string) (hash256 []byte, err error) {
+	var fstats os.FileInfo
+	fstats, err = os.Lstat(fname)
+	if err != nil {
+		return nil, err
+	}
+	if fstats.Mode()&os.ModeSymlink != 0 {
+		var target string
+		target, err = os.Readlink(fname)
+		return []byte(SHA256(target)), nil
+	}
+	if err != nil {
+		return nil, err
+	}
 	return IMOHashFile(fname)
 }
 


### PR DESCRIPTION
When transfering a symlink, `croc` tries to calculate the hash of the symlinked file (i. e., the target).  This breaks when the symlink is broken.  However, there is no reason a broken symlink should not be transferable as well.  This just requires `croc` to take a hash of the symlink itself (e. g., its target), which is what this patch does.

Example:

```
$ ln -s a b; ls -l b; croc send b
lrwxrwxrwx 1 tdussa tdussa 1 Apr 15 17:12 b -> a
2021/04/15 17:12:17 stat b: no such file or directory
```

With the suggested patch, the transfer works as expected:
```
$ ln -s a b; ls -l b; croc send b
lrwxrwxrwx 1 tdussa tdussa 1 Apr 15 17:15 b -> a
Sending 'b' (1 B)
Code is: ruby-hazard-guru
On the other computer run

croc ruby-hazard-guru
```