### PR TITLE
Use unprivileged user in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ EXPOSE 9011
 EXPOSE 9012
 EXPOSE 9013
 COPY --from=builder /go/croc/croc /go/croc/croc-entrypoint.sh /
+USER nobody
 ENTRYPOINT ["/croc-entrypoint.sh"]
 CMD ["relay"]


### PR DESCRIPTION
See 
https://americanexpress.io/do-not-run-dockerized-applications-as-root/
and 
https://engineering.bitnami.com/articles/why-non-root-containers-are-important-for-security.html