### PR TITLE
refactor: Accept enter in prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ bash_autocomplete
 dist
 bin
 croc-stdin*
+
+.idea/
+.vscode/

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -116,8 +116,9 @@ func Run() (err error) {
 				_, basename := filepath.Split(fpath)
 				fnames = append(fnames, "'"+basename+"'")
 			}
-			yn := utils.GetInput(fmt.Sprintf("Did you mean to send %s? (y/n) ", strings.Join(fnames, ", ")))
-			if strings.ToLower(yn) == "y" {
+			promptMessage := fmt.Sprintf("Did you mean to send %s? (Y/n) ", strings.Join(fnames, ", "))
+			choice := strings.ToLower(utils.GetInput(promptMessage))
+			if choice == "" || choice == "y" || choice == "yes" {
 				return send(c)
 			}
 		}
@@ -335,7 +336,6 @@ func makeTempFileWithString(s string) (fnames []string, err error) {
 	}
 	fnames = []string{f.Name()}
 	return
-
 }
 
 func getPaths(fnames []string) (paths []string, haveFolder bool, err error) {


### PR DESCRIPTION
Until now, the process of receiving a file was aborted when an empty entry (`Enter`) was made. It is common under *nix that pressing `Enter` without prior input of other characters selects the default answer. This would make the workflow with croc easier.

In most usecases the default choice will be `Y`/`Yes`. The only exception is the prompt for overwriting existing files. We default to `N`/`No` in this prompt to prevent accidental overwriting of files.

Additionally I've added the folders `.idea/` and `.vscode/` to the gitignore file.