### PR TITLE
Make internal DNS resolution opt-in

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -80,6 +80,7 @@ func Run() (err error) {
 		},
 	}
 	app.Flags = []cli.Flag{
+		&cli.BoolFlag{Name: "internal-dns", Usage: "use a built-in DNS stub resolver rather than the host operating system"},
 		&cli.BoolFlag{Name: "remember", Usage: "save these settings to reuse next time"},
 		&cli.BoolFlag{Name: "debug", Usage: "toggle debug mode"},
 		&cli.BoolFlag{Name: "yes", Usage: "automatically agree to all prompts"},

--- a/src/models/constants.go
+++ b/src/models/constants.go
@@ -39,7 +39,6 @@ func init() {
 			break
 		}
 	}
-
 	var err error
 	DEFAULT_RELAY, err = lookup(DEFAULT_RELAY)
 	if err == nil {
@@ -60,23 +59,22 @@ func lookup(address string) (ipaddress string, err error) {
 	if !INTERNAL_DNS {
 		return localLookupIP(address)
 	}
-
 	result := make(chan string, len(publicDns))
 	for _, dns := range publicDns {
 		go func(dns string) {
-			s, _ := remoteLookupIP(address, dns)
-			result <- s
+			s, err := remoteLookupIP(address, dns)
+			if err == nil {
+				result <- s
+			}
 		}(dns)
 	}
-
 	for i := 0; i < len(publicDns); i++ {
 		ipaddress = <-result
 		if ipaddress != "" {
 			return
 		}
 	}
-
-	err = fmt.Errorf("failed to lookup %s at any DNS server", address)
+	err = fmt.Errorf("failed to resolve %s: all DNS servers exhausted", address)
 	return
 }
 

--- a/src/models/constants.go
+++ b/src/models/constants.go
@@ -23,13 +23,22 @@ var (
 var publicDns = []string{
 	"1.0.0.1",                // Cloudflare
 	"1.1.1.1",                // Cloudflare
+	"[2606:4700:4700::1111]", // Cloudflare
+	"[2606:4700:4700::1001]", // Cloudflare
 	"8.8.4.4",                // Google
 	"8.8.8.8",                // Google
-	"8.26.56.26",             // Comodo
-	"208.67.220.220",         // Cisco OpenDNS
-	"208.67.222.222",         // Cisco OpenDNS
 	"[2001:4860:4860::8844]", // Google
 	"[2001:4860:4860::8888]", // Google
+	"9.9.9.9",                // Quad9
+	"149.112.112.112",        // Quad9
+	"[2620:fe::fe]",          // Quad9
+	"[2620:fe::fe:9]",        // Quad9
+	"8.26.56.26",             // Comodo
+	"8.20.247.20",            // Comodo
+	"208.67.220.220",         // Cisco OpenDNS
+	"208.67.222.222",         // Cisco OpenDNS
+	"[2620:119:35::35]",      // Cisco OpenDNS
+	"[2620:119:53::53]",      // Cisco OpenDNS
 }
 
 func init() {


### PR DESCRIPTION
This PR disables croc's internal DNS by default and adds an opt-in `--internal-dns` flag to bypass the local stub resolver if necessary (e.g. poorly configured ephemeral hosts).

Fixes #389.