### PR TITLE
Add host flag for relay

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -83,6 +83,7 @@ func Run() (err error) {
 				return relay(c)
 			},
 			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "host", Usage: "host of the relay"},
 				&cli.StringFlag{Name: "ports", Value: "9009,9010,9011,9012,9013", Usage: "ports of the relay"},
 			},
 		},
@@ -519,6 +520,7 @@ func relay(c *cli.Context) (err error) {
 	if c.Bool("debug") {
 		debugString = "debug"
 	}
+	host := c.String("host")
 	ports := strings.Split(c.String("ports"), ",")
 	tcpPorts := strings.Join(ports[1:], ",")
 	for i, port := range ports {
@@ -526,11 +528,11 @@ func relay(c *cli.Context) (err error) {
 			continue
 		}
 		go func(portStr string) {
-			err = tcp.Run(debugString, portStr, determinePass(c))
+			err = tcp.Run(debugString, host, portStr, determinePass(c))
 			if err != nil {
 				panic(err)
 			}
 		}(port)
 	}
-	return tcp.Run(debugString, ports[0], determinePass(c), tcpPorts)
+	return tcp.Run(debugString, host, ports[0], determinePass(c), tcpPorts)
 }

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -291,7 +291,7 @@ func (c *Client) setupLocalRelay() {
 			if c.Options.Debug {
 				debugString = "debug"
 			}
-			err := tcp.Run(debugString, portStr, c.Options.RelayPassword, strings.Join(c.Options.RelayPorts[1:], ","))
+			err := tcp.Run(debugString, "localhost", portStr, c.Options.RelayPassword, strings.Join(c.Options.RelayPorts[1:], ","))
 			if err != nil {
 				panic(err)
 			}

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -15,11 +15,11 @@ import (
 func init() {
 	log.SetLevel("trace")
 
-	go tcp.Run("debug", "8081", "pass123", "8082,8083,8084,8085")
-	go tcp.Run("debug", "8082", "pass123")
-	go tcp.Run("debug", "8083", "pass123")
-	go tcp.Run("debug", "8084", "pass123")
-	go tcp.Run("debug", "8085", "pass123")
+	go tcp.Run("debug", "localhost", "8081", "pass123", "8082,8083,8084,8085")
+	go tcp.Run("debug", "localhost", "8082", "pass123")
+	go tcp.Run("debug", "localhost", "8083", "pass123")
+	go tcp.Run("debug", "localhost", "8084", "pass123")
+	go tcp.Run("debug", "localhost", "8085", "pass123")
 	time.Sleep(1 * time.Second)
 }
 

--- a/src/tcp/tcp_test.go
+++ b/src/tcp/tcp_test.go
@@ -12,7 +12,7 @@ import (
 
 func BenchmarkConnection(b *testing.B) {
 	log.SetLevel("trace")
-	go Run("debug", "8283", "pass123", "8284")
+	go Run("debug", "localhost", "8283", "pass123", "8284")
 	time.Sleep(100 * time.Millisecond)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -24,7 +24,7 @@ func BenchmarkConnection(b *testing.B) {
 func TestTCP(t *testing.T) {
 	log.SetLevel("error")
 	timeToRoomDeletion = 100 * time.Millisecond
-	go Run("debug", "8281", "pass123", "8282")
+	go Run("debug", "localhost", "8281", "pass123", "8282")
 	time.Sleep(100 * time.Millisecond)
 	err := PingServer("localhost:8281")
 	assert.Nil(t, err)


### PR DESCRIPTION
Resolved #416.

Although `net.Listen("tcp", addr)` display IPv6, it also provides support for IPv4, ref golang/go#9334.

```bash
$ croc relay
[info]  2021/10/01 13:00:34 starting croc relay version v9.3.0-94b2aff
[info]  2021/10/01 13:00:34 starting TCP server on :9009
[info]  2021/10/01 13:00:34 starting TCP server on :9012
[info]  2021/10/01 13:00:34 starting TCP server on :9011
[info]  2021/10/01 13:00:34 starting TCP server on :9010
[info]  2021/10/01 13:00:34 starting TCP server on :9013

$ lsof -i :9009
COMMAND   PID     USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
main    31243 kallydev    5u  IPv6 0x786f7593799ac31b      0t0  TCP *:pichat (LISTEN)
```

```
$ croc relay --host 0.0.0.0
[info]  2021/10/01 12:58:49 starting croc relay version v9.3.0-94b2aff
[info]  2021/10/01 12:58:49 starting TCP server on 0.0.0.0:9009
[info]  2021/10/01 12:58:49 starting TCP server on 0.0.0.0:9011
[info]  2021/10/01 12:58:49 starting TCP server on 0.0.0.0:9013
[info]  2021/10/01 12:58:49 starting TCP server on 0.0.0.0:9012
[info]  2021/10/01 12:58:49 starting TCP server on 0.0.0.0:9010

$ lsof -i :9009
COMMAND   PID     USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
main    31367 kallydev    5u  IPv4 0x786f7593a7a196f3      0t0  TCP *:pichat (LISTEN)
```

```bash
$ croc relay --host :: 
[info]  2021/10/01 12:59:46 starting croc relay version v9.3.0-94b2aff
[info]  2021/10/01 12:59:46 starting TCP server on [::]:9009
[info]  2021/10/01 12:59:46 starting TCP server on [::]:9011
[info]  2021/10/01 12:59:46 starting TCP server on [::]:9010
[info]  2021/10/01 12:59:46 starting TCP server on [::]:9012
[info]  2021/10/01 12:59:46 starting TCP server on [::]:9013

$ lsof -i :9009
COMMAND   PID     USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
main    31308 kallydev    5u  IPv6 0x786f75937d8c79db      0t0  TCP *:pichat (LISTEN)
```