### PR TITLE
Fix TCP constant

### DIFF
--- a/src/tcp/tcp.go
+++ b/src/tcp/tcp.go
@@ -37,10 +37,9 @@ type roomMap struct {
 	sync.Mutex
 }
 
-const (
-	timeToRoomDeletion = 10 * time.Minute
-	pingRoom           = "pinglkasjdlfjsaldjf"
-)
+const pingRoom = "pinglkasjdlfjsaldjf"
+
+var timeToRoomDeletion = 10 * time.Minute
 
 // Run starts a tcp listener, run async
 func Run(debugLevel, host, port, password string, banner ...string) (err error) {

--- a/src/tcp/tcp_test.go
+++ b/src/tcp/tcp_test.go
@@ -25,13 +25,13 @@ func TestTCP(t *testing.T) {
 	log.SetLevel("error")
 	timeToRoomDeletion = 100 * time.Millisecond
 	go Run("debug", "localhost", "8281", "pass123", "8282")
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(timeToRoomDeletion)
 	err := PingServer("localhost:8281")
 	assert.Nil(t, err)
 	err = PingServer("localhost:8333")
 	assert.NotNil(t, err)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(timeToRoomDeletion)
 	c1, banner, _, err := ConnectToTCPServer("localhost:8281", "pass123", "testRoom", 1*time.Minute)
 	assert.Equal(t, banner, "8282")
 	assert.Nil(t, err)


### PR DESCRIPTION
Followup to #420 

My apologies! I remember running the tests, but I must have made these changes after that. Regardless, I introduced some failing tests. This PR fixes that by changing the offending `const` back to a `var`.

cc @maximbaz 