### PR TITLE
Run tests via Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: go test ./...


### PR DESCRIPTION
A proposal to run tests in CI, to avoid accidents like https://github.com/schollz/croc/pull/424

If merged first, the tests would be failing, until https://github.com/schollz/croc/pull/424 is merged and fixes the tests.

Feel free to take over and adjust as you wish, if you want to experiment 🙂 