### PR TITLE
Fixed an error

### DIFF
--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -684,7 +684,7 @@ main() {
     print_message "== Install prefix already exists. No need to create it." "info"
   fi
 
-
+  [ ! -d "/etc/bash_completion.d/croc" ] && mkdir -p "/etc/bash_completion.d/croc"
   case "${croc_os}" in
     "Linux" ) install_file_linux "${tmpdir}/${croc_bin_name}" "${prefix}/";
               install_file_rcode="${?}";;


### PR DESCRIPTION
Fixed an error thrown after running "curl https://getcroc.schollz.com/ | bash", which shows "install: failed to access '/etc/bash_completion.d/croc': No such file or directory". I found that the content on getcroc.schollz.com is exactly the same to this file and this error is definitely caused by nonexistence of the directory /etc/bash_completion.d/croc.

So I hope that you can update the content on getcroc.schollz.com at the same time. Thank you!