### PR TITLE
build: upgrade to Go 1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
+      with:
+        go-version: '1.17'
     - run: go version
     - run: go test -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.16-alpine as builder
+FROM golang:1.17-alpine as builder
 RUN apk add --no-cache git
 WORKDIR /go/croc
 COPY . .
 RUN go build -v -ldflags="-s -w"
 
-FROM alpine:latest 
+FROM alpine:latest
 EXPOSE 9009
 EXPOSE 9010
 EXPOSE 9011

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ On FreeBSD you can install with `pkg`:
 pkg install croc
 ```
 
-Or, you can [install Go](https://golang.org/dl/) and build from source (requires Go 1.15+): 
+Or, you can [install Go](https://golang.org/dl/) and build from source (requires Go 1.17+): 
 
 ```
 go install github.com/schollz/croc/v9@latest

--- a/go.mod
+++ b/go.mod
@@ -1,27 +1,38 @@
 module github.com/schollz/croc/v9
 
-go 1.13
+go 1.17
 
 require (
-	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/cespare/xxhash v1.1.0
-	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/kalafut/imohash v1.0.2
-	github.com/kr/pretty v0.1.0 // indirect
 	github.com/schollz/cli/v2 v2.2.1
 	github.com/schollz/logger v1.2.0
 	github.com/schollz/mnemonicode v1.0.1
 	github.com/schollz/pake/v3 v3.0.2
 	github.com/schollz/peerdiscovery v1.6.9
 	github.com/schollz/progressbar/v3 v3.8.3
-	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/tscholl2/siec v0.0.0-20210707234609-9bdfc483d499 // indirect
-	github.com/twmb/murmur3 v1.1.6 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6
+)
+
+require (
+	github.com/OneOfOne/xxhash v1.2.5 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/tscholl2/siec v0.0.0-20210707234609-9bdfc483d499 // indirect
+	github.com/twmb/murmur3 v1.1.6 // indirect
+	golang.org/x/sys v0.0.0-20211002104244-808efd93c36d // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -177,7 +176,7 @@ func getConfigFile() string {
 
 func determinePass(c *cli.Context) (pass string) {
 	pass = c.String("pass")
-	b, err := ioutil.ReadFile(pass)
+	b, err := os.ReadFile(pass)
 	if err == nil {
 		pass = strings.TrimSpace(string(b))
 	}
@@ -213,7 +212,7 @@ func send(c *cli.Context) (err error) {
 	} else if crocOptions.RelayAddress6 != models.DEFAULT_RELAY6 {
 		crocOptions.RelayAddress = ""
 	}
-	b, errOpen := ioutil.ReadFile(getConfigFile())
+	b, errOpen := os.ReadFile(getConfigFile())
 	if errOpen == nil && !c.Bool("remember") {
 		var rememberedOptions croc.Options
 		err = json.Unmarshal(b, &rememberedOptions)
@@ -310,7 +309,7 @@ func send(c *cli.Context) (err error) {
 }
 
 func getStdin() (fnames []string, err error) {
-	f, err := ioutil.TempFile(".", "croc-stdin-")
+	f, err := os.CreateTemp(".", "croc-stdin-")
 	if err != nil {
 		return
 	}
@@ -327,7 +326,7 @@ func getStdin() (fnames []string, err error) {
 }
 
 func makeTempFileWithString(s string) (fnames []string, err error) {
-	f, err := ioutil.TempFile(".", "croc-stdin-")
+	f, err := os.CreateTemp(".", "croc-stdin-")
 	if err != nil {
 		return
 	}
@@ -401,7 +400,7 @@ func saveConfig(c *cli.Context, crocOptions croc.Options) {
 			log.Error(err)
 			return
 		}
-		err = ioutil.WriteFile(configFile, bConfig, 0644)
+		err = os.WriteFile(configFile, bConfig, 0644)
 		if err != nil {
 			log.Error(err)
 			return
@@ -451,7 +450,7 @@ func receive(c *cli.Context) (err error) {
 		return
 	}
 	configFile = path.Join(configFile, "receive.json")
-	b, errOpen := ioutil.ReadFile(configFile)
+	b, errOpen := os.ReadFile(configFile)
 	if errOpen == nil && !c.Bool("remember") {
 		var rememberedOptions croc.Options
 		err = json.Unmarshal(b, &rememberedOptions)
@@ -509,7 +508,7 @@ func receive(c *cli.Context) (err error) {
 			log.Error(err)
 			return
 		}
-		err = ioutil.WriteFile(configFile, bConfig, 0644)
+		err = os.WriteFile(configFile, bConfig, 0644)
 		if err != nil {
 			log.Error(err)
 			return

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -1482,7 +1481,7 @@ func (c *Client) receiveData(i int) {
 					c.FilesToTransfer[c.FilesToTransferCurrentNum].FolderRemote,
 					c.FilesToTransfer[c.FilesToTransferCurrentNum].Name,
 				)
-				b, _ := ioutil.ReadFile(pathToFile)
+				b, _ := os.ReadFile(pathToFile)
 				fmt.Print(string(b))
 			}
 			log.Debug("sending close-sender")

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -1,7 +1,6 @@
 package croc
 
 import (
-	"io/ioutil"
 	"os"
 	"sync"
 	"testing"
@@ -153,7 +152,7 @@ func TestCrocLocal(t *testing.T) {
 
 func TestCrocError(t *testing.T) {
 	content := []byte("temporary file's content")
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		panic(err)
 	}

--- a/src/install/updateversion.go
+++ b/src/install/updateversion.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -43,7 +42,7 @@ func run() (err error) {
 }
 
 func replaceInFile(fname, start, end, replacement string) (err error) {
-	b, err := ioutil.ReadFile(fname)
+	b, err := os.ReadFile(fname)
 	if err != nil {
 		return
 	}
@@ -58,7 +57,7 @@ func replaceInFile(fname, start, end, replacement string) (err error) {
 		fmt.Sprintf("%s%s%s", start, replacement, end),
 		1,
 	)
-	err = ioutil.WriteFile(fname, []byte(newF), 0644)
+	err = os.WriteFile(fname, []byte(newF), 0644)
 	return
 }
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"math/big"
@@ -136,7 +135,7 @@ func PublicIP() (ip string, err error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", err
 		}
@@ -283,7 +282,7 @@ func GetLocalIPs() (ips []string, err error) {
 }
 
 func RandomFileName() (fname string, err error) {
-	f, err := ioutil.TempFile(".", "croc-stdin-")
+	f, err := os.CreateTemp(".", "croc-stdin-")
 	if err != nil {
 		return
 	}

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -17,7 +16,7 @@ import (
 var bigFileSize = 75000000
 
 func bigFile() {
-	ioutil.WriteFile("bigfile.test", bytes.Repeat([]byte("z"), bigFileSize), 0666)
+	os.WriteFile("bigfile.test", bytes.Repeat([]byte("z"), bigFileSize), 0666)
 }
 
 func BenchmarkMD5(b *testing.B) {
@@ -119,7 +118,7 @@ func TestMissingChunks(t *testing.T) {
 	rand.Seed(1)
 	bigBuff := make([]byte, fileSize)
 	rand.Read(bigBuff)
-	ioutil.WriteFile("missing.test", bigBuff, 0644)
+	os.WriteFile("missing.test", bigBuff, 0644)
 	empty := make([]byte, chunkSize)
 	f, err := os.OpenFile("missing.test", os.O_RDWR, 0644)
 	assert.Nil(t, err)
@@ -139,7 +138,7 @@ func TestMissingChunks(t *testing.T) {
 	os.Remove("missing.test")
 
 	content := []byte("temporary file's content")
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -171,7 +170,7 @@ func TestMissingChunks(t *testing.T) {
 
 func TestHashFile(t *testing.T) {
 	content := []byte("temporary file's content")
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This pull request introduces two small changes:

1. Enable  [module graph pruning](https://golang.org/ref/mod#graph-pruning) and [lazy module loading](https://golang.org/ref/mod#lazy-loading) supported by Go 1.17 or higher. 

1. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Tis PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.