### PR TITLE
#431 fixed remote path

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -267,7 +267,7 @@ func send(c *cli.Context) (err error) {
 		crocOptions.SharedSecret = utils.GetRandomName()
 	}
 
-	paths, haveFolder, err := getPaths(fnames)
+	minimalFileInfos, err := croc.GetFilesInfo(fnames)
 	if err != nil {
 		return
 	}
@@ -280,10 +280,7 @@ func send(c *cli.Context) (err error) {
 	// save the config
 	saveConfig(c, crocOptions)
 
-	err = cr.Send(croc.TransferOptions{
-		PathToFiles:      paths,
-		KeepPathInRemote: haveFolder,
-	})
+	err = cr.Send(minimalFileInfos)
 
 	return
 }
@@ -324,47 +321,6 @@ func makeTempFileWithString(s string) (fnames []string, err error) {
 	return
 }
 
-func getPaths(fnames []string) (paths []string, haveFolder bool, err error) {
-	haveFolder = false
-	paths = []string{}
-	for _, fname := range fnames {
-		// Support wildcard
-		if strings.Contains(fname, "*") {
-			matches, errGlob := filepath.Glob(fname)
-			if errGlob != nil {
-				err = errGlob
-				return
-			}
-			paths = append(paths, matches...)
-			continue
-		}
-
-		stat, errStat := os.Lstat(fname)
-		if errStat != nil {
-			err = errStat
-			return
-		}
-		if stat.IsDir() {
-			haveFolder = true
-			err = filepath.Walk(fname,
-				func(pathName string, info os.FileInfo, err error) error {
-					if err != nil {
-						return err
-					}
-					if !info.IsDir() {
-						paths = append(paths, filepath.ToSlash(pathName))
-					}
-					return nil
-				})
-			if err != nil {
-				return
-			}
-		} else {
-			paths = append(paths, filepath.ToSlash(fname))
-		}
-	}
-	return
-}
 
 func saveConfig(c *cli.Context, crocOptions croc.Options) {
 	if c.Bool("remember") {

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -258,7 +258,6 @@ func GetFilesInfo(fnames []string) (filesInfo []FileInfo, err error) {
 		}
 
 		absPath, errAbs := filepath.Abs(path)
-		absPath = filepath.ToSlash(absPath)
 
 		if errAbs != nil {
 			err = errAbs
@@ -272,10 +271,12 @@ func GetFilesInfo(fnames []string) (filesInfo []FileInfo, err error) {
 						return err
 					}
 					if !info.IsDir() {
+
+						remoteFolder := strings.TrimPrefix(filepath.Dir(pathName),
+							filepath.Dir(absPath)+string(os.PathSeparator))
 						filesInfo = append(filesInfo, FileInfo{
-							Name: info.Name(),
-							FolderRemote: strings.TrimPrefix(filepath.Dir(filepath.ToSlash(pathName)),
-								filepath.Dir(absPath)+"/"),
+							Name:         info.Name(),
+							FolderRemote: strings.Replace(remoteFolder, string(os.PathSeparator), "/", -1) + "/",
 							FolderSource: filepath.Dir(pathName),
 							Size:         info.Size(),
 							ModTime:      info.ModTime(),
@@ -1601,7 +1602,7 @@ func (c *Client) sendData(i int) {
 		n, errRead := c.fread.ReadAt(data, readingPos)
 		// log.Debugf("%d read %d bytes", i, n)
 		readingPos += int64(n)
-		if (c.limiter != nil) {
+		if c.limiter != nil {
 			r := c.limiter.ReserveN(time.Now(), n)
 			log.Debugf("Limiting Upload for %d", r.Delay())
 			time.Sleep(r.Delay())

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -63,9 +63,11 @@ func TestCrocReadme(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		err := sender.Send(TransferOptions{
-			PathToFiles: []string{"../../README.md"},
-		})
+		filesInfo, errGet := GetFilesInfo([]string{"../../README.md"})
+		if errGet != nil {
+			t.Errorf("failed to get minimal info: %v", errGet)
+		}
+		err := sender.Send(filesInfo)
 		if err != nil {
 			t.Errorf("send failed: %v", err)
 		}
@@ -129,10 +131,11 @@ func TestCrocLocal(t *testing.T) {
 	os.Create("touched")
 	wg.Add(2)
 	go func() {
-		err := sender.Send(TransferOptions{
-			PathToFiles:      []string{"../../LICENSE", "touched"},
-			KeepPathInRemote: false,
-		})
+		filesInfo, errGet := GetFilesInfo([]string{"../../LICENSE", "touched"})
+		if errGet != nil {
+			t.Errorf("failed to get minimal info: %v", errGet)
+		}
+		err := sender.Send(filesInfo)
 		if err != nil {
 			t.Errorf("send failed: %v", err)
 		}
@@ -181,10 +184,11 @@ func TestCrocError(t *testing.T) {
 		Curve:         "siec",
 		Overwrite:     true,
 	})
-	err = sender.Send(TransferOptions{
-		PathToFiles:      []string{tmpfile.Name()},
-		KeepPathInRemote: true,
-	})
+	filesInfo, errGet := GetFilesInfo([]string{tmpfile.Name()})
+	if errGet != nil {
+		t.Errorf("failed to get minimal info: %v", errGet)
+	}
+	err = sender.Send(filesInfo)
 	log.Debug(err)
 	assert.NotNil(t, err)
 


### PR DESCRIPTION
What was the problem?

When we tried to compute the remote path, we used the following formula: file absolute path (every file from every folder we wanted to send) - the absolute path from the current folder. This will not work for files outside the current one.

Solution:

For each file path we want to be in a folder at the destination, we calculate the remote folder path with the following formula:
absolute file path - the absolute path to the parent folder of the one given as an argument in CLI

Ex:
 
Suppose we have a folder1 that contains folder2, and folder2 includes a file named test.txt
If we use the command: "croc send general-path-pattern/folder1/folder2" this will result in the creation of folder2 with the file that it contains in the remote client.

Now we can send files from everywhere, including different partitions in Windows(if we use absolute paths).  