### PR TITLE
Drop shebang for bash completion

### DIFF
--- a/src/install/bash_autocomplete
+++ b/src/install/bash_autocomplete
@@ -1,5 +1,3 @@
-#! /bin/bash
-
 : ${PROG:=$(basename ${BASH_SOURCE})}
 
 _cli_bash_autocomplete() {


### PR DESCRIPTION
Bash completions are sourced, not executed, so they don't need to have a shebang.