### PR TITLE
Add a warning for SIEC as the default curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+⚠️**WARNING:** By default `croc` uses the SIEC curve (which hasn't received third-party cryptanalysis), however, it can be [changed to use standardized curves such as P-256 and P-384](#change-encryption-curve).
+
+---
 
 <p align="center">
 <img


### PR DESCRIPTION
As of right now, SIEC hasn't received third-party cryptanalysis (from searching online, I wasn't able to find anything, unfortunately). For the benefit of the community, it should be made clear that this is the case. And it should be easy to guide users to changing the default curve, hence why I included a link to jump to the appropriate section.

Seeing as #468 has taken some negative light, I want to make it clear that I have no intent of disparaging the work of `croc`, SIEC, or any persons involved.