### PR TITLE
Fixed #463 issue

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -267,7 +267,7 @@ func send(c *cli.Context) (err error) {
 		crocOptions.SharedSecret = utils.GetRandomName()
 	}
 
-	minimalFileInfos, err := croc.GetFilesInfo(fnames)
+	minimalFileInfos, emptyFoldersToTransfer, totalNumberFolders, err := croc.GetFilesInfo(fnames)
 	if err != nil {
 		return
 	}
@@ -280,7 +280,7 @@ func send(c *cli.Context) (err error) {
 	// save the config
 	saveConfig(c, crocOptions)
 
-	err = cr.Send(minimalFileInfos)
+	err = cr.Send(minimalFileInfos, emptyFoldersToTransfer, totalNumberFolders)
 
 	return
 }

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -65,11 +66,76 @@ func TestCrocReadme(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		filesInfo, errGet := GetFilesInfo([]string{"../../README.md"})
+		filesInfo, emptyFolders, totalNumberFolders, errGet := GetFilesInfo([]string{"../../README.md"})
 		if errGet != nil {
 			t.Errorf("failed to get minimal info: %v", errGet)
 		}
-		err := sender.Send(filesInfo)
+		err := sender.Send(filesInfo, emptyFolders, totalNumberFolders)
+		if err != nil {
+			t.Errorf("send failed: %v", err)
+		}
+		wg.Done()
+	}()
+	time.Sleep(100 * time.Millisecond)
+	go func() {
+		err := receiver.Receive()
+		if err != nil {
+			t.Errorf("receive failed: %v", err)
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+func TestCrocEmptyFolder(t *testing.T) {
+	pathName := "../../testEmpty"
+	defer os.RemoveAll(pathName)
+	os.MkdirAll(pathName, 0755)
+
+	log.Debug("setting up sender")
+	sender, err := New(Options{
+		IsSender:      true,
+		SharedSecret:  "8123-testingthecroc",
+		Debug:         true,
+		RelayAddress:  "localhost:8281",
+		RelayPorts:    []string{"8281"},
+		RelayPassword: "pass123",
+		Stdout:        false,
+		NoPrompt:      true,
+		DisableLocal:  true,
+		Curve:         "siec",
+		Overwrite:     true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	log.Debug("setting up receiver")
+	receiver, err := New(Options{
+		IsSender:      false,
+		SharedSecret:  "8123-testingthecroc",
+		Debug:         true,
+		RelayAddress:  "localhost:8281",
+		RelayPassword: "pass123",
+		Stdout:        false,
+		NoPrompt:      true,
+		DisableLocal:  true,
+		Curve:         "siec",
+		Overwrite:     true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		filesInfo, emptyFolders, totalNumberFolders, errGet := GetFilesInfo([]string{pathName})
+		if errGet != nil {
+			t.Errorf("failed to get minimal info: %v", errGet)
+		}
+		err := sender.Send(filesInfo, emptyFolders, totalNumberFolders)
 		if err != nil {
 			t.Errorf("send failed: %v", err)
 		}
@@ -131,11 +197,11 @@ func TestCrocSymlink(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		filesInfo, errGet := GetFilesInfo([]string{pathName})
+		filesInfo, emptyFolders, totalNumberFolders, errGet := GetFilesInfo([]string{pathName})
 		if errGet != nil {
 			t.Errorf("failed to get minimal info: %v", errGet)
 		}
-		err := sender.Send(filesInfo)
+		err := sender.Send(filesInfo, emptyFolders, totalNumberFolders)
 		if err != nil {
 			t.Errorf("send failed: %v", err)
 		}
@@ -153,7 +219,8 @@ func TestCrocSymlink(t *testing.T) {
 	wg.Wait()
 
 	s, err := filepath.EvalSymlinks(path.Join(pathName, "README.link"))
-	if s != "../../README.md" {
+	if s != "../../README.md" && s != "..\\..\\README.md" {
+		log.Debug(s)
 		t.Errorf("symlink failed to transfer in folder")
 	}
 	if err != nil {
@@ -207,11 +274,11 @@ func TestCrocLocal(t *testing.T) {
 	os.Create("touched")
 	wg.Add(2)
 	go func() {
-		filesInfo, errGet := GetFilesInfo([]string{"../../LICENSE", "touched"})
+		filesInfo, emptyFolders, totalNumberFolders, errGet := GetFilesInfo([]string{"../../LICENSE", "touched"})
 		if errGet != nil {
 			t.Errorf("failed to get minimal info: %v", errGet)
 		}
-		err := sender.Send(filesInfo)
+		err := sender.Send(filesInfo, emptyFolders, totalNumberFolders)
 		if err != nil {
 			t.Errorf("send failed: %v", err)
 		}
@@ -260,12 +327,42 @@ func TestCrocError(t *testing.T) {
 		Curve:         "siec",
 		Overwrite:     true,
 	})
-	filesInfo, errGet := GetFilesInfo([]string{tmpfile.Name()})
+	filesInfo, emptyFolders, totalNumberFolders, errGet := GetFilesInfo([]string{tmpfile.Name()})
 	if errGet != nil {
 		t.Errorf("failed to get minimal info: %v", errGet)
 	}
-	err = sender.Send(filesInfo)
+	err = sender.Send(filesInfo, emptyFolders, totalNumberFolders)
 	log.Debug(err)
 	assert.NotNil(t, err)
+}
 
+func TestCleanUp(t *testing.T) {
+	// windows allows files to be deleted only if they
+	// are not open by another program so the remove actions
+	// from the above tests will not always do a good clean up
+	// This "test" will make sure
+	operatingSystem := runtime.GOOS
+	log.Debugf("The operating system is %s", operatingSystem)
+	if operatingSystem == "windows" {
+		time.Sleep(1 * time.Second)
+		log.Debug("Full cleanup")
+		var err error
+
+		for _, file := range []string{"README.md", "./README.md"} {
+			err = os.Remove(file)
+			if err == nil {
+				log.Debugf("Successfuly purged %s", file)
+			} else {
+				log.Debug("%s was already purged.", file)
+			}
+		}
+		for _, folder := range []string{"./testEmpty", "./link-in-folder"} {
+			err = os.RemoveAll(folder)
+			if err == nil {
+				log.Debugf("Successfuly purged %s", folder)
+			} else {
+				log.Debug("%s was already purged.", folder)
+			}
+		}
+	}
 }

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -91,6 +91,7 @@ func TestCrocReadme(t *testing.T) {
 func TestCrocEmptyFolder(t *testing.T) {
 	pathName := "../../testEmpty"
 	defer os.RemoveAll(pathName)
+	defer os.RemoveAll("./testEmpty")
 	os.MkdirAll(pathName, 0755)
 
 	log.Debug("setting up sender")
@@ -156,6 +157,7 @@ func TestCrocEmptyFolder(t *testing.T) {
 func TestCrocSymlink(t *testing.T) {
 	pathName := "../link-in-folder"
 	defer os.RemoveAll(pathName)
+	defer os.RemoveAll("./link-in-folder")
 	os.MkdirAll(pathName, 0755)
 	os.Symlink("../../README.md", filepath.Join(pathName, "README.link"))
 
@@ -353,7 +355,7 @@ func TestCleanUp(t *testing.T) {
 			if err == nil {
 				log.Debugf("Successfuly purged %s", file)
 			} else {
-				log.Debug("%s was already purged.", file)
+				log.Debugf("%s was already purged.", file)
 			}
 		}
 		for _, folder := range []string{"./testEmpty", "./link-in-folder"} {
@@ -361,7 +363,7 @@ func TestCleanUp(t *testing.T) {
 			if err == nil {
 				log.Debugf("Successfuly purged %s", folder)
 			} else {
-				log.Debug("%s was already purged.", folder)
+				log.Debugf("%s was already purged.", folder)
 			}
 		}
 	}


### PR DESCRIPTION
Cause: when sending an empty folder, the program threw an error because filesToTransfer was nil, so a problem occurred when trying to process it for transfer.

Solution: add a new field in the client to take into account all empty folders to be sent and made sure that if filesToTransfer is nil, then we jump to the last step of the transfer protocol and signal the server that all went OK. 

New features:
-  All sent empty folders will be created at the receiver's end.
-  If the empty folder that is sent is already at the receiver's end and has some content in it, the user can chose if it will keep the content or not.
-  Changed the receiver's transfer progress display to show all the empty folders that were created.

Additions to tests:
- Modified croc test to perform better clean up in Windows.
- Added new test for empty folders.
- Enabled the symlink test to function in Windows (though it still requires Administrator privileges).
