### PR TITLE
add Fedora instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ On Arch Linux you can install the latest release with `pacman`:
 pacman -S croc
 ```
 
+On Fedora you can install with `dnf`:
+
+```
+dnf install croc
+```
+
 On Gentoo you can install with `portage`:
 ```
 emerge net-misc/croc


### PR DESCRIPTION
croc is now packaged in Fedora 35+ releases: https://src.fedoraproject.org/rpms/golang-github-schollz-croc