### PR TITLE
Fix relay IPv4 address resolution behind DNS64

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -778,7 +778,7 @@ func (c *Client) Receive() (err error) {
 					continue
 				}
 
-				serverTry := fmt.Sprintf("%s:%s", ip, port)
+				serverTry := net.JoinHostPort(ip, port)
 				conn, banner2, externalIP, errConn := tcp.ConnectToTCPServer(serverTry, c.Options.RelayPassword, c.Options.SharedSecret[:3], 500*time.Millisecond)
 				if errConn != nil {
 					log.Debug(errConn)

--- a/src/models/constants.go
+++ b/src/models/constants.go
@@ -79,15 +79,16 @@ func init() {
 		}
 	}
 	var err error
-	DEFAULT_RELAY, err = lookup(DEFAULT_RELAY)
+	var addr string
+	addr, err = lookup(DEFAULT_RELAY)
 	if err == nil {
-		DEFAULT_RELAY += ":" + DEFAULT_PORT
+		DEFAULT_RELAY = net.JoinHostPort(addr, DEFAULT_PORT)
 	} else {
 		DEFAULT_RELAY = ""
 	}
-	DEFAULT_RELAY6, err = lookup(DEFAULT_RELAY6)
+	addr, err = lookup(DEFAULT_RELAY6)
 	if err == nil {
-		DEFAULT_RELAY6 = "[" + DEFAULT_RELAY6 + "]:" + DEFAULT_PORT
+		DEFAULT_RELAY6 = net.JoinHostPort(addr, DEFAULT_PORT)
 	} else {
 		DEFAULT_RELAY6 = ""
 	}


### PR DESCRIPTION
## Problem
The IPv4 address/port of the relay is resolved to `64:ff9b::5a1:458f:9009` behind resolvers that use DNS64.
When croc tries to connect to it it will fail. It should be `[64:ff9b::5a1:458f]:9009` instead, which will properly be routed through the NAT64 gateway and translated to IPv4.

## Changes
`init()` in `constants.go` now uses the stdlib `net.JoinHostPort()`, which handles this situation correctly. It should always be used when concatenating IP addresses and ports, even if the address class is (assumed to be) known.

Same change has been done to `Client.Retrieve()`, although this wasn't related to the problem.