### PR TITLE
Package as a snap (https://snapcraft.io/)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: croc
+version: git
+summary: Easily and securely send things from one computer to another
+description: Easily and securely send things from one computer to another
+confinement: classic
+base: core20
+
+parts:
+  docker-image-save:
+    plugin: go
+    source: https://github.com/schollz/croc
+    source-type: git
+    build-packages:
+      - gcc
+
+apps:
+  croc:
+    command: bin/croc
+    plugs:
+      - network
+      - network-bind


### PR DESCRIPTION
Snaps are very convenient for software distribution.
It'll make it even easier to install and update `croc` on systems that already use snaps like Ubuntu.

After merging this branch, sign up at https://snapcraft.io/ and link the project and GitHub repository.
Snapcraft takes care of builds and edge releases. Only stable releases need some manual interaction.

Thank you very much for this great application :-)