### PR TITLE
fix #493: data race in cli.relay

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -470,7 +470,7 @@ func relay(c *cli.Context) (err error) {
 			continue
 		}
 		go func(portStr string) {
-			err = tcp.Run(debugString, host, portStr, determinePass(c))
+			err := tcp.Run(debugString, host, portStr, determinePass(c))
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
Closes #493 by declaring a new `err` variable inside the goroutine (and prevent capturing the `err` return value)