### PR TITLE
update dockerfile to v1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine as builder
+FROM golang:1.19-alpine as builder
 RUN apk add --no-cache git
 WORKDIR /go/croc
 COPY . .


### PR DESCRIPTION
I missed one place to update in my previous PR. I did a global search at the time for 1.18, but apparently the dockerfile was still at 1.17.

It's my hope that this will fix the failing builds for the 386 platform I'm seeing