### PR TITLE
Feat: support http proxy as a complementary way to use in network limited environments.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/magisterquis/connectproxy v0.0.0-20200725203833-3582e84f0c9b
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/magisterquis/connectproxy v0.0.0-20200725203833-3582e84f0c9b h1:xZ59n7Frzh8CwyfAapUZLSg+gXH5m63YEaFCMpDHhpI=
+github.com/magisterquis/connectproxy v0.0.0-20200725203833-3582e84f0c9b/go.mod h1:uDd4sYVYsqcxAB8j+Q7uhL6IJCs/r1kxib1HV4bgOMg=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -106,6 +106,7 @@ func Run() (err error) {
 		&cli.StringFlag{Name: "out", Value: ".", Usage: "specify an output folder to receive the file"},
 		&cli.StringFlag{Name: "pass", Value: models.DEFAULT_PASSPHRASE, Usage: "password for the relay", EnvVars: []string{"CROC_PASS"}},
 		&cli.StringFlag{Name: "socks5", Value: "", Usage: "add a socks5 proxy", EnvVars: []string{"SOCKS5_PROXY"}},
+		&cli.StringFlag{Name: "connect", Value: "", Usage: "add a http proxy", EnvVars: []string{"HTTP_PROXY"}},
 		&cli.StringFlag{Name: "throttleUpload", Value: "", Usage: "Throttle the upload speed e.g. 500k"},
 	}
 	app.EnableBashCompletion = true
@@ -170,6 +171,7 @@ func determinePass(c *cli.Context) (pass string) {
 func send(c *cli.Context) (err error) {
 	setDebugLevel(c)
 	comm.Socks5Proxy = c.String("socks5")
+	comm.HttpProxy = c.String("connect")
 	portsString := c.String("ports")
 	if portsString == "" {
 		portsString = "9009,9010,9011,9012,9013"
@@ -388,6 +390,7 @@ func (t TabComplete) Do(line []rune, pos int) ([][]rune, int) {
 
 func receive(c *cli.Context) (err error) {
 	comm.Socks5Proxy = c.String("socks5")
+	comm.HttpProxy = c.String("connect")
 	crocOptions := croc.Options{
 		SharedSecret:  c.String("code"),
 		IsSender:      false,

--- a/src/comm/comm.go
+++ b/src/comm/comm.go
@@ -61,7 +61,7 @@ func NewConnection(address string, timelimit ...time.Duration) (c *Comm, err err
 		}
 		HttpProxyURL, urlParseError := url.Parse(HttpProxy)
 		if urlParseError != nil {
-			err = fmt.Errorf("unable to parse socks proxy url: %s", urlParseError)
+			err = fmt.Errorf("unable to parse http proxy url: %s", urlParseError)
 			log.Debug(err)
 			return
 		}


### PR DESCRIPTION
In some network limited environments and only having HTTP proxy is hard to use croc, so I added this feature.
This feature is to use HTTP connect method to establish a tunnel between croc client and the replay server.
Usage:
1. send: `croc -connect="http://proxy_addr" filename`
2. receive: `croc -connect="http://proxy_addr" code`