### PR TITLE
switch winget releaser runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish:
-    runs-on: windows-latest # Action can only run on Windows
+    runs-on: ubuntu-latest
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
Winget Releaser now supports non-Windows runners, and the `ubuntu-latest` runner is generally faster.

Also, the latest run failed: https://github.com/schollz/croc/actions/runs/5478246443/jobs/9978462966. Was the token expired or invalid? I have manually created a PR for the version for now: https://github.com/microsoft/winget-pkgs/pull/111529.