### PR TITLE
fix architecture detection for Apple Silicon

### DIFF
--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -587,6 +587,7 @@ main() {
      "x86_64" ) croc_arch="64bit";;
       "amd64" ) croc_arch="64bit";;
     "aarch64" ) croc_arch="ARM64";;
+      "arm64" ) croc_arch="ARM64";;
      "armv7l" ) croc_arch="ARM";;
        "i686" ) croc_arch="32bit";;
             * ) croc_arch="unknown";;


### PR DESCRIPTION
Auto-installation on a fresh install of macOS Apple Silicon with

#  curl -k https://getcroc.schollz.com | bash 

fails, because the installer is looking for # uname -a to report the architecture as "aarch64", while in fact macOS reports "arm64".

Fix this by recognizing "arm64" as a synonym for "aarch64".

Note: this bug only shows on a fresh install of macOS. If croc has been installed previously, the existing install script detects the architecture as "macOS-64bit" and (incorrectly) installs the x86_64 binary, which, of course, also works.