### PR TITLE
zip file bug on windows and linux

### DIFF
--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -402,6 +402,7 @@ func ZipDirectory(destination string, source string) (err error) {
 			}
 			defer f1.Close()
 			zipPath := strings.ReplaceAll(path, source, strings.TrimSuffix(destination, ".zip"))
+			zipPath = filepath.ToSlash(zipPath)
 			w1, err := writer.Create(zipPath)
 			if err != nil {
 				log.Fatalln(err)


### PR DESCRIPTION
If there are directories in a zip file compressed on the Windows platform, the "\\" in the filepath will cause the files to be extracted normally on Linux, and ls will show filenames containing single quotes.

So when compressing, I replace "\\" with "/" so that it seems there are no issues on both Windows and Linux.