### PR TITLE
Add printing receive command as a qr code with new --qrcode flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	golang.org/x/time v0.3.0
 )
 
+require github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
+
 require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/schollz/peerdiscovery v1.7.0/go.mod h1:BouGdURKIFl7OGez+2lyZJKD+2tBQ2
 github.com/schollz/progressbar/v3 v3.13.1 h1:o8rySDYiQ59Mwzy2FELeHY5ZARXZTVJC7iHD6PEFUiE=
 github.com/schollz/progressbar/v3 v3.13.1/go.mod h1:xvrbki8kfT1fzWzBT/UZd9L6GA+jdL7HAgq2RFnO6fQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -65,6 +65,7 @@ func Run() (err error) {
 			ArgsUsage:   "[filename(s) or folder]",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{Name: "zip", Usage: "zip folder before sending"},
+		        &cli.BoolFlag{Name: "qrcode",Aliases: []string{"qr"}, Usage: "show receive code as a qrcode"},
 				&cli.StringFlag{Name: "code", Aliases: []string{"c"}, Usage: "codephrase used to connect to relay"},
 				&cli.StringFlag{Name: "hash", Value: "xxhash", Usage: "hash algorithm (xxhash, imohash, md5)"},
 				&cli.StringFlag{Name: "text", Aliases: []string{"t"}, Usage: "send some text"},
@@ -89,7 +90,6 @@ func Run() (err error) {
 	}
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{Name: "internal-dns", Usage: "use a built-in DNS stub resolver rather than the host operating system"},
-		&cli.BoolFlag{Name: "qrcode", Usage: "show receive command as qrcode"},
 		&cli.BoolFlag{Name: "remember", Usage: "save these settings to reuse next time"},
 		&cli.BoolFlag{Name: "debug", Usage: "toggle debug mode"},
 		&cli.BoolFlag{Name: "yes", Usage: "automatically agree to all prompts"},

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -89,6 +89,7 @@ func Run() (err error) {
 	}
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{Name: "internal-dns", Usage: "use a built-in DNS stub resolver rather than the host operating system"},
+		&cli.BoolFlag{Name: "qrcode", Usage: "show receive command as qrcode"},
 		&cli.BoolFlag{Name: "remember", Usage: "save these settings to reuse next time"},
 		&cli.BoolFlag{Name: "debug", Usage: "toggle debug mode"},
 		&cli.BoolFlag{Name: "yes", Usage: "automatically agree to all prompts"},
@@ -198,6 +199,7 @@ func send(c *cli.Context) (err error) {
 		HashAlgorithm:  c.String("hash"),
 		ThrottleUpload: c.String("throttleUpload"),
 		ZipFolder:      c.Bool("zip"),
+		ShowQrCode:     c.Bool("qrcode"),
 	}
 	if crocOptions.RelayAddress != models.DEFAULT_RELAY {
 		crocOptions.RelayAddress6 = ""

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -32,8 +32,8 @@ import (
 	"github.com/schollz/croc/v9/src/models"
 	"github.com/schollz/croc/v9/src/tcp"
 	"github.com/schollz/croc/v9/src/utils"
+	qrcode "github.com/skip2/go-qrcode"
 )
-import qrcode "github.com/skip2/go-qrcode"
 var (
 	ipRequest        = []byte("ips?")
 	handshakeRequest = []byte("handshake")

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -531,7 +531,7 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 	}
 	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\n\ncroc %[2]s%[1]s\n", c.Options.SharedSecret, flags.String())
 	if c.Options.ShowQrCode {
-	    showReceiveCommandQrCode(fmt.Sprintf("croc %[2]s%[1]s", c.Options.SharedSecret, flags.String()))
+	    showReceiveCommandQrCode(fmt.Sprintf("%[1]s", c.Options.SharedSecret))
 	}
 	if c.Options.Ask {
 		machid, _ := machineid.ID()

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -33,7 +33,7 @@ import (
 	"github.com/schollz/croc/v9/src/tcp"
 	"github.com/schollz/croc/v9/src/utils"
 )
-
+import qrcode "github.com/skip2/go-qrcode"
 var (
 	ipRequest        = []byte("ips?")
 	handshakeRequest = []byte("handshake")
@@ -77,6 +77,7 @@ type Options struct {
 	ThrottleUpload string
 	ZipFolder      bool
 	TestFlag       bool
+	ShowQrCode     bool
 }
 
 // Client holds the state of the croc transfer
@@ -529,6 +530,9 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 		flags.WriteString("--pass " + c.Options.RelayPassword + " ")
 	}
 	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\n\ncroc %[2]s%[1]s\n", c.Options.SharedSecret, flags.String())
+	if c.Options.ShowQrCode {
+	    showReceiveCommandQrCode(fmt.Sprintf("croc %[2]s%[1]s", c.Options.SharedSecret, flags.String()))
+	}
 	if c.Options.Ask {
 		machid, _ := machineid.ID()
 		fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)
@@ -653,7 +657,12 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 	}
 	return err
 }
-
+func showReceiveCommandQrCode(command string){
+  qrCode, err := qrcode.New(command, qrcode.Medium)
+  if err == nil {
+    fmt.Println(qrCode.ToSmallString(false))
+  }
+}
 // Receive will receive a file
 func (c *Client) Receive() (err error) {
 	fmt.Fprintf(os.Stderr, "connecting...")


### PR DESCRIPTION
Hi guys, 

This pull request adds a new feature to the Croc software, allowing users to display the receive command as a QR code by using the --qrcode flag. This feature enhances the usability and convenience of Croc by providing an easily scannable QR code representation of the receive command.I also plan to add scan qrcode feature in croc android soon.

Changes Made:
1. Added a new command-line flag --qrcode to the Croc software.
2. When the --qrcode flag is used, the receive command is extracted and converted into a QR code using the go-qrcode library.
3. The QR code is displayed to the user in the command-line interface.
<img width="393" alt="image" src="https://github.com/schollz/croc/assets/7608032/da2a0fea-0c30-49c4-8474-03143e9a95b8">

Benefits:
1. Improved user experience: Users can now conveniently display the receive command as a QR code, making it easier to scan and share.
2. Enhanced accessibility: The QR code representation allows users to use QR code scanning applications or libraries to automate the process of capturing the receive command.
3. Increased efficiency: By providing a direct QR code display option, users can quickly access the receive command without manually typing or copying it.

P/s: This is my first time of using go lang so Im not sure what i'm is in good practice, so please let me know if i should improve something. Thank you in advanced . 