### PR TITLE
Fix for the failing CD build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     name: Go unit tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: '1.20'
     - run: go version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: schollz/croc
           # generate Docker tags based on the following events/attributes
@@ -41,20 +41,20 @@ jobs:
             type=sha
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.19-alpine as builder
-RUN apk add --no-cache git
+FROM golang:1.20-alpine as builder
+RUN apk add --no-cache git gcc musl-dev
 WORKDIR /go/croc
 COPY . .
 RUN go build -v -ldflags="-s -w"


### PR DESCRIPTION
Unfortunately #645 still failed to publish the latest artifacts to DockerHub. The issue does not happen in local testing which leads me to believe it is to do with the legacy architectures. The logs of the failure also indicate in that direction.

I have disabled the legacy 386 and 32-bit arm build in this fix to get the normal images published. Perhaps a more detailed analysis and fix would be required for enabling the legacy builds again. The problem seams to be around these flags `-ldflags="-s -w"`

Also It looks like the CI build is using the go version 1.20 so I bumped that to be consistent. 