### PR TITLE
hide relay param if not going to be used

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -623,7 +623,7 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 		return
 	}
 	flags := &strings.Builder{}
-	if c.Options.RelayAddress != models.DEFAULT_RELAY {
+	if c.Options.RelayAddress != models.DEFAULT_RELAY && !c.Options.OnlyLocal {
 		flags.WriteString("--relay " + c.Options.RelayAddress + " ")
 	}
 	if c.Options.RelayPassword != models.DEFAULT_PASSPHRASE {


### PR DESCRIPTION
Right now, when defining a different than the default relay will print it in the command, even when using `OnlyLocal` mode, which doesn't make much sense.

Fixes #616 