### PR TITLE
remove unnecessary trailing newline character when stdout is enabled

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -1098,7 +1098,7 @@ func (c *Client) transfer() (err error) {
 		if err = os.Remove(pathToFile); err != nil {
 			log.Warnf("error removing %s: %v", pathToFile, err)
 		}
-		fmt.Print("\n")
+		fmt.Fprint(os.Stderr, "\n")
 	}
 	if err != nil && strings.Contains(err.Error(), "pake not successful") {
 		log.Debugf("pake error: %s", err.Error())

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -18,7 +18,7 @@ import (
 func init() {
 	log.SetLevel("trace")
 
-	go tcp.Run("debug", "127.0.0.1", "8281", "pass123", "8282,8283,8284,8285")
+	go tcp.Run("debug", "127.0.0.1", "8281", "pass123", "8281,4")
 	go tcp.Run("debug", "127.0.0.1", "8282", "pass123")
 	go tcp.Run("debug", "127.0.0.1", "8283", "pass123")
 	go tcp.Run("debug", "127.0.0.1", "8284", "pass123")
@@ -35,7 +35,7 @@ func TestCrocReadme(t *testing.T) {
 		SharedSecret:  "8123-testingthecroc",
 		Debug:         true,
 		RelayAddress:  "127.0.0.1:8281",
-		RelayPorts:    []string{"8281"},
+		BasePort:      8281,
 		RelayPassword: "pass123",
 		Stdout:        false,
 		NoPrompt:      true,
@@ -102,7 +102,7 @@ func TestCrocEmptyFolder(t *testing.T) {
 		SharedSecret:  "8123-testingthecroc",
 		Debug:         true,
 		RelayAddress:  "127.0.0.1:8281",
-		RelayPorts:    []string{"8281"},
+		BasePort:      8281,
 		RelayPassword: "pass123",
 		Stdout:        false,
 		NoPrompt:      true,
@@ -169,7 +169,7 @@ func TestCrocSymlink(t *testing.T) {
 		SharedSecret:  "8124-testingthecroc",
 		Debug:         true,
 		RelayAddress:  "127.0.0.1:8281",
-		RelayPorts:    []string{"8281"},
+		BasePort:      8281,
 		RelayPassword: "pass123",
 		Stdout:        false,
 		NoPrompt:      true,
@@ -271,7 +271,8 @@ func TestCrocLocal(t *testing.T) {
 		SharedSecret:  "8123-testingthecroc",
 		Debug:         true,
 		RelayAddress:  "127.0.0.1:8181",
-		RelayPorts:    []string{"8181", "8182"},
+		BasePort:      8181,
+		TransferPorts: 1,
 		RelayPassword: "pass123",
 		Stdout:        true,
 		NoPrompt:      true,
@@ -351,7 +352,8 @@ func TestCrocError(t *testing.T) {
 		SharedSecret:  "8123-testingthecroc2",
 		Debug:         true,
 		RelayAddress:  "doesntexistok.com:8381",
-		RelayPorts:    []string{"8381", "8382"},
+		BasePort:      8381,
+		TransferPorts: 1,
 		RelayPassword: "pass123",
 		Stdout:        true,
 		NoPrompt:      true,


### PR DESCRIPTION
#624 
Output the newline character to stderr to ensure consistency between the content sent and the content output to stdout.