### PR TITLE
remove unnecessary trailing newline character when stdout is enabled

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -1044,7 +1044,7 @@ func (c *Client) transfer() (err error) {
 		if err = os.Remove(pathToFile); err != nil {
 			log.Warnf("error removing %s: %v", pathToFile, err)
 		}
-		fmt.Print("\n")
+		fmt.Fprint(os.Stderr, "\n")
 	}
 	if err != nil && strings.Contains(err.Error(), "pake not successful") {
 		log.Debugf("pake error: %s", err.Error())


### PR DESCRIPTION
#624
#661 
reopen pr for this change 