### PR TITLE
Build release binaries for DragonFly/Free/Net/OpenBSD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,22 @@ jobs:
         tar -czvf croc_${{ github.event.release.name }}_macOS-64bit.tar.gz croc
         CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags '-s -extldflags "-sectcreate __TEXT __info_plist Info.plist"' -o croc
         tar -czvf croc_${{ github.event.release.name }}_macOS-ARM64.tar.gz croc
+        CGO_ENABLED=0 GOOS=dragonfly GOARCH=amd64 go build -ldflags '' -o croc
+        tar -czvf croc_${{ github.event.release.name }}_DragonFlyBSD-64bit.tar.gz croc
+        CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64 go build -ldflags '' -o croc
+        tar -czvf croc_${{ github.event.release.name }}_FreeBSD-64bit.tar.gz croc
+        CGO_ENABLED=0 GOOS=freebsd GOARCH=arm64 go build -ldflags '' -o croc
+        tar -czvf croc_${{ github.event.release.name }}_FreeBSD-ARM64.tar.gz croc
+        CGO_ENABLED=0 GOOS=netbsd GOARCH=386 go build -ldflags '' -o croc
+        tar -czvf croc_${{ github.event.release.name }}_NetBSD-32bit.tar.gz croc
+        CGO_ENABLED=0 GOOS=netbsd GOARCH=amd64 go build -ldflags '' -o croc
+        tar -czvf croc_${{ github.event.release.name }}_NetBSD-64bit.tar.gz croc
+        CGO_ENABLED=0 GOOS=netbsd GOARCH=arm64 go build -ldflags '' -o croc
+        tar -czvf croc_${{ github.event.release.name }}_NetBSD-ARM64.tar.gz croc
+        CGO_ENABLED=0 GOOS=openbsd GOARCH=amd64 go build -ldflags '' -o croc
+        tar -czvf croc_${{ github.event.release.name }}_OpenBSD-64bit.tar.gz croc
+        CGO_ENABLED=0 GOOS=openbsd GOARCH=arm64 go build -ldflags '' -o croc
+        tar -czvf croc_${{ github.event.release.name }}_OpenBSD-ARM64.tar.gz croc
     - name: Create checksums.txt
       run: |
         touch croc_${{ github.event.release.name }}_checksums.txt
@@ -71,6 +87,14 @@ jobs:
         sha256sum croc_${{ github.event.release.name }}_Linux-ARM64.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
         sha256sum croc_${{ github.event.release.name }}_macOS-64bit.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
         sha256sum croc_${{ github.event.release.name }}_macOS-ARM64.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
+        sha256sum croc_${{ github.event.release.name }}_DragonFlyBSD-64bit.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
+        sha256sum croc_${{ github.event.release.name }}_FreeBSD-64bit.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
+        sha256sum croc_${{ github.event.release.name }}_FreeBSD-ARM64.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
+        sha256sum croc_${{ github.event.release.name }}_NetBSD-32bit.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
+        sha256sum croc_${{ github.event.release.name }}_NetBSD-64bit.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
+        sha256sum croc_${{ github.event.release.name }}_NetBSD-ARM64.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
+        sha256sum croc_${{ github.event.release.name }}_OpenBSD-64bit.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
+        sha256sum croc_${{ github.event.release.name }}_OpenBSD-ARM64.tar.gz >> croc_${{ github.event.release.name }}_checksums.txt
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
@@ -89,4 +113,11 @@ jobs:
           croc_${{ github.event.release.name }}_Linux-ARM64.tar.gz
           croc_${{ github.event.release.name }}_macOS-64bit.tar.gz
           croc_${{ github.event.release.name }}_macOS-ARM64.tar.gz 
-
+          croc_${{ github.event.release.name }}_DragonFlyBSD-64bit.tar.gz
+          croc_${{ github.event.release.name }}_FreeBSD-64bit.tar.gz
+          croc_${{ github.event.release.name }}_FreeBSD-ARM64.tar.gz
+          croc_${{ github.event.release.name }}_NetBSD-32bit.tar.gz
+          croc_${{ github.event.release.name }}_NetBSD-64bit.tar.gz
+          croc_${{ github.event.release.name }}_NetBSD-ARM64.tar.gz
+          croc_${{ github.event.release.name }}_OpenBSD-64bit.tar.gz
+          croc_${{ github.event.release.name }}_OpenBSD-ARM64.tar.gz


### PR DESCRIPTION
This PR modifies the release workflow to build binaries for DragonFly BSD, FreeBSD, NetBSD, and OpenBSD. The updated workflow builds binaries for AMD64 and ARM64 for those systems that support them. DragonFly BSD only supports AMD64, so only one binary is built. For NetBSD, it also builds an i386 binary because a major use of NetBSD is retrocomputing.

The workflow succeeds on my fork of the repository: https://github.com/dbohdan/croc/actions/runs/8011298184, https://github.com/dbohdan/croc/releases/tag/release-test. (The test branch includes an extra commit to change the repository URL in the workflow file to mine. The commit isn't part of this PR.)
