### PR TITLE
Fix Windows builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -20,9 +20,9 @@ jobs:
         go-version: '1.20'
     - name: Build Windows 7
       run: |
-        CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -tags netgo -ldflags '-H=windowsgui -extldflags "-static"' -o croc.exe
+        CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags '-extldflags "-static"' -o croc.exe
         zip croc_${{ github.event.release.name }}_Windows7-64bit.zip croc.exe
-        CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -tags netgo -ldflags '-H=windowsgui -extldflags "-static"' -o croc.exe
+        CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags '-extldflags "-static"' -o croc.exe
         zip croc_${{ github.event.release.name }}_Windows7-32bit.zip croc.exe
     - name: Setup Go
       uses: actions/setup-go@v4
@@ -35,21 +35,21 @@ jobs:
         cd .. && tar -czvf croc_${{ github.event.release.name }}_src.tar.gz croc-${{ github.event.release.name }}
     - name: Build files
       run: |
-        CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -tags netgo -ldflags '-H=windowsgui -extldflags "-static"' -o croc.exe
+        CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags '-extldflags "-static"' -o croc.exe
         zip croc_${{ github.event.release.name }}_Windows-64bit.zip croc.exe LICENSE
-        CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -tags netgo -ldflags '-H=windowsgui -extldflags "-static"' -o croc.exe
+        CGO_ENABLED=0 GOOS=windows GOARCH=386 go build -ldflags '-extldflags "-static"' -o croc.exe
         zip croc_${{ github.event.release.name }}_Windows-32bit.zip croc.exe LICENSE
-        CGO_ENABLED=0 GOOS=windows GOARCH=arm go build -tags netgo -ldflags '-H=windowsgui -extldflags "-static"' -o croc.exe
+        CGO_ENABLED=0 GOOS=windows GOARCH=arm go build -ldflags '-extldflags "-static"' -o croc.exe
         zip croc_${{ github.event.release.name }}_Windows-ARM.zip croc.exe LICENSE
-        CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -tags netgo -ldflags '-H=windowsgui -extldflags "-static"' -o croc.exe
+        CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -ldflags '-extldflags "-static"' -o croc.exe
         zip croc_${{ github.event.release.name }}_Windows-ARM64.zip croc.exe LICENSE
-        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags netgo -ldflags '-extldflags "-static"' -o croc
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static"' -o croc
         tar -czvf croc_${{ github.event.release.name }}_Linux-64bit.tar.gz croc LICENSE
-        CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -tags netgo -ldflags '-extldflags "-static"' -o croc
+        CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags '-extldflags "-static"' -o croc
         tar -czvf croc_${{ github.event.release.name }}_Linux-32bit.tar.gz croc LICENSE
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -tags netgo -ldflags '-extldflags "-static"' -o croc
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags '-extldflags "-static"' -o croc
         tar -czvf croc_${{ github.event.release.name }}_Linux-ARM.tar.gz croc LICENSE
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -tags netgo -ldflags '-extldflags "-static"' -o croc
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags '-extldflags "-static"' -o croc
         tar -czvf croc_${{ github.event.release.name }}_Linux-ARM64.tar.gz croc LICENSE
         CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags '-s -extldflags "-sectcreate __TEXT __info_plist Info.plist"' -o croc
         tar -czvf croc_${{ github.event.release.name }}_macOS-64bit.tar.gz croc LICENSE


### PR DESCRIPTION
Windows builds are broken by 4159ba766873d4e86b5abaa776ba4150a65f465b.
Fix by:
 - Remove the `-H=windowsgui` ldflag, which flags the program as GUI, giving no output to console.
 - Remove the `netgo` tag, which causes a significant delay of about 30 seconds, for the program to start.

Fixes #668.