### PR TITLE
Update error message to be more verbose

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -1052,7 +1052,7 @@ func (c *Client) transfer() (err error) {
 	}
 	if err != nil && strings.Contains(err.Error(), "unexpected end of JSON input") {
 		log.Debugf("error: %s", err.Error())
-		err = fmt.Errorf("room not ready")
+		err = fmt.Errorf("room (secure channel) not ready, maybe peer disconnected")
 	}
 	return
 }


### PR DESCRIPTION
Summary
----
This changes the error message (when connecting to an unavailable channel) like so:

before:

```
$ croc 6764-jimmy-hilton-inside
securing channel...2024/03/28 17:16:25 room not ready
```

after:

```
$ ./croc 6764-jimmy-hilton-inside
securing channel...2024/03/28 17:16:12 room (secure channel) not ready, maybe peer disconnected
```

PS: This is just a suggestion, I personally find the verbosity of the error message to convey the meaning better.