### PR TITLE
Support spaces in 4 word codes

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -435,6 +435,8 @@ func receive(c *cli.Context) (err error) {
 	case 1:
 		crocOptions.SharedSecret = c.Args().First()
 	case 3:
+		fallthrough
+	case 4:
 		var phrase []string
 		phrase = append(phrase, c.Args().First())
 		phrase = append(phrase, c.Args().Tail()...)


### PR DESCRIPTION
Since the code was extended by the 4 digit block, the patch from https://github.com/schollz/croc/pull/198 did not work anymore.