### PR TITLE
Check $HOME as last

### DIFF
--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -32,16 +32,15 @@ const NbBytesWords = 4
 
 // Get or create home directory
 func GetConfigDir() (homedir string, err error) {
-	homedir, err = os.UserHomeDir()
-	if err != nil {
-		return
-	}
-
 	if envHomedir, isSet := os.LookupEnv("CROC_CONFIG_DIR"); isSet {
 		homedir = envHomedir
 	} else if xdgConfigHome, isSet := os.LookupEnv("XDG_CONFIG_HOME"); isSet {
 		homedir = path.Join(xdgConfigHome, "croc")
 	} else {
+		homedir, err = os.UserHomeDir()
+		if err != nil {
+			return
+		}
 		homedir = path.Join(homedir, ".config", "croc")
 	}
 


### PR DESCRIPTION
As described in https://github.com/schollz/croc/issues/681 croc crashs with 
```
$HOME is not defined
```
if `$HOME` is empty. 
The code also checks for `$CROC_CONFIG_DIR` and `$XDG_CONFIG_HOME`  though only if `$HOME` is set.
This patch moves the check for `$HOME` at the end, so that it does not crash if `$CROC_CONFIG_DIR` or `$XDG_CONFIG_HOME` is set and a config home is found.