### PR TITLE
Gracefully handle non existend receive config file

### DIFF
--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -32,16 +32,15 @@ const NbBytesWords = 4
 
 // Get or create home directory
 func GetConfigDir() (homedir string, err error) {
-	homedir, err = os.UserHomeDir()
-	if err != nil {
-		return
-	}
-
 	if envHomedir, isSet := os.LookupEnv("CROC_CONFIG_DIR"); isSet {
 		homedir = envHomedir
 	} else if xdgConfigHome, isSet := os.LookupEnv("XDG_CONFIG_HOME"); isSet {
 		homedir = path.Join(xdgConfigHome, "croc")
 	} else {
+		homedir, err = os.UserHomeDir()
+		if err != nil {
+			return
+		}
 		homedir = path.Join(homedir, ".config", "croc")
 	}
 


### PR DESCRIPTION
This PR is based on https://github.com/schollz/croc/pull/684

As I understand the handling of `send.json` in the  `send` function, it prints but ignores an error of `utils.GetConfigDir()`. I tried to copy this behavior to the `receive` function:

If `utils.GetConfigDir()` fails, the error is printed and returned to `receive`. Though, croc only exits if `c.Bool("remember")` is `true`, because only then, the config file is really needed.

This may be related to #681 

