### PR TITLE
Avoid to create config dir if not required

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -153,8 +153,8 @@ func setDebugLevel(c *cli.Context) {
 	}
 }
 
-func getSendConfigFile() string {
-	configFile, err := utils.GetConfigDir()
+func getSendConfigFile(requireValidPath bool) string {
+	configFile, err := utils.GetConfigDir(requireValidPath)
 	if err != nil {
 		log.Error(err)
 		return ""
@@ -162,8 +162,8 @@ func getSendConfigFile() string {
 	return path.Join(configFile, "send.json")
 }
 
-func getReceiveConfigFile() (string, error) {
-	configFile, err := utils.GetConfigDir()
+func getReceiveConfigFile(requireValidPath bool) (string, error) {
+	configFile, err := utils.GetConfigDir(requireValidPath)
 	if err != nil {
 		log.Error(err)
 		return "", err
@@ -228,7 +228,7 @@ func send(c *cli.Context) (err error) {
 	} else if crocOptions.RelayAddress6 != models.DEFAULT_RELAY6 {
 		crocOptions.RelayAddress = ""
 	}
-	b, errOpen := os.ReadFile(getSendConfigFile())
+	b, errOpen := os.ReadFile(getSendConfigFile(false))
 	if errOpen == nil && !c.Bool("remember") {
 		var rememberedOptions croc.Options
 		err = json.Unmarshal(b, &rememberedOptions)
@@ -364,7 +364,7 @@ func makeTempFileWithString(s string) (fnames []string, err error) {
 
 func saveConfig(c *cli.Context, crocOptions croc.Options) {
 	if c.Bool("remember") {
-		configFile := getSendConfigFile()
+		configFile := getSendConfigFile(true)
 		log.Debug("saving config file")
 		var bConfig []byte
 		// if the code wasn't set, don't save it

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -455,12 +455,13 @@ func receive(c *cli.Context) (err error) {
 	// load options here
 	setDebugLevel(c)
 
-	configFile, err := getReceiveConfigFile()
-	if err != nil && c.Bool("remember") {
+	doRemember := c.Bool("remember")
+	configFile, err := getReceiveConfigFile(doRemember)
+	if err != nil && doRemember {
 		return
 	}
 	b, errOpen := os.ReadFile(configFile)
-	if errOpen == nil && !c.Bool("remember") {
+	if errOpen == nil && !doRemember {
 		var rememberedOptions croc.Options
 		err = json.Unmarshal(b, &rememberedOptions)
 		if err != nil {
@@ -519,7 +520,7 @@ func receive(c *cli.Context) (err error) {
 	}
 
 	// save the config
-	if c.Bool("remember") {
+	if doRemember {
 		log.Debug("saving config file")
 		var bConfig []byte
 		bConfig, err = json.MarshalIndent(crocOptions, "", "    ")

--- a/src/models/constants.go
+++ b/src/models/constants.go
@@ -44,8 +44,8 @@ var publicDNS = []string{
 	"[2620:119:53::53]",      // Cisco OpenDNS
 }
 
-func getConfigFile() (fname string, err error) {
-	configFile, err := utils.GetConfigDir()
+func getConfigFile(requireValidPath bool) (fname string, err error) {
+	configFile, err := utils.GetConfigDir(requireValidPath)
 	if err != nil {
 		return
 	}
@@ -66,14 +66,14 @@ func init() {
 	}
 	if doRemember {
 		// save in config file
-		fname, err := getConfigFile()
+		fname, err := getConfigFile(true)
 		if err == nil {
 			f, _ := os.Create(fname)
 			f.Close()
 		}
 	}
 	if !INTERNAL_DNS {
-		fname, err := getConfigFile()
+		fname, err := getConfigFile(false)
 		if err == nil {
 			INTERNAL_DNS = utils.Exists(fname)
 		}

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -31,7 +31,7 @@ const NbPinNumbers = 4
 const NbBytesWords = 4
 
 // Get or create home directory
-func GetConfigDir() (homedir string, err error) {
+func GetConfigDir(requireValidPath bool) (homedir string, err error) {
 	if envHomedir, isSet := os.LookupEnv("CROC_CONFIG_DIR"); isSet {
 		homedir = envHomedir
 	} else if xdgConfigHome, isSet := os.LookupEnv("XDG_CONFIG_HOME"); isSet {
@@ -39,13 +39,19 @@ func GetConfigDir() (homedir string, err error) {
 	} else {
 		homedir, err = os.UserHomeDir()
 		if err != nil {
+			if !requireValidPath {
+				err = nil
+				homedir = ""
+			}
 			return
 		}
 		homedir = path.Join(homedir, ".config", "croc")
 	}
 
-	if _, err = os.Stat(homedir); os.IsNotExist(err) {
-		err = os.MkdirAll(homedir, 0o700)
+	if requireValidPath {
+		if _, err = os.Stat(homedir); os.IsNotExist(err) {
+			err = os.MkdirAll(homedir, 0o700)
+		}
 	}
 	return
 }


### PR DESCRIPTION
The config directory must only exist if `--remember` is set.

Otherwise croc only tries to read the config file on the returned path, that already could be `""` if 	`utils.GetConfigDir()` returns an error and if the config file does not exist during read, errors are already silently ignored. 

Edit: should fix https://github.com/schollz/croc/issues/681