### PR TITLE
Add receiving on Linux and classic mode to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ go install github.com/schollz/croc/v10@latest
 On Android there is a 3rd party F-Droid app [available to download](https://f-droid.org/en/packages/com.github.howeyc.crocgui/).
 
 
-## Usage 
+## Usage
 
 To send a file, simply do: 
 
@@ -129,9 +129,32 @@ Then to receive the file (or folder) on another computer, you can just do
 croc code-phrase
 ```
 
+On Linux this behavior is disabled by default to avoid leaking the [secret via the process name](https://nvd.nist.gov/vuln/detail/CVE-2023-43621) ([see below](README.md#receiving-on-linux)).
+
 The code phrase is used to establish password-authenticated key agreement ([PAKE](https://en.wikipedia.org/wiki/Password-authenticated_key_agreement)) which generates a secret key for the sender and recipient to use for end-to-end encryption.
 
 There are a number of configurable options (see `--help`). A set of options (like custom relay, ports, and code phrase) can be set using `--remember`.
+
+### Receiving on Linux
+
+On Linux receiving is slightly different to avoid [leaking the secret via the process name](https://nvd.nist.gov/vuln/detail/CVE-2023-43621).
+Run
+
+```
+CROC_SECRET=*** croc
+```
+
+to receive with secret `***`. 
+It will show only `croc` in the process list of a multi-user system.
+
+For a single-user system the default behavior can be permanently enabled by running
+
+```
+croc --classic
+```
+
+and confirming. 
+Run this command again to disable classic mode.
 
 ### Custom code phrase
 
@@ -167,7 +190,7 @@ croc --yes [code-phrase] > out
 All of the other text printed to the console is going to `stderr` so it will not interfere with the message going to `stdout`.
 
 
-### Send text 
+### Send text
 
 Sometimes you want to send URLs or short text. In addition to piping, you can easily send text with `croc`:
 


### PR DESCRIPTION
This adds a mention of receiving on Linux and `--classic` mode to the README. 