### PR TITLE
Use echo + pipe to avoid leaking secret in process name

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -385,11 +385,12 @@ you need to set the environmental variable CROC_SECRET:
   export CROC_SECRET="****"
   croc send file.txt
 
-Or you can have the code phrase automaticlaly generated:
+Or you can have the code phrase automatically generated:
 
   croc send file.txt
-	
-Or you can go back to the classic croc behavior by enabling classic mode:
+
+Or you can go back to the classic croc behavior by enabling classic mode,
+though this can leak the secret via the process name:
 
   croc --classic
 
@@ -597,18 +598,23 @@ func receive(c *cli.Context) (err error) {
 		crocOptions.SharedSecret = os.Getenv("CROC_SECRET")
 		if crocOptions.SharedSecret == "" {
 			fmt.Printf(`On UNIX systems, to receive with croc you either need 
-to set a code phrase using your environmental variables:
-	
-  export CROC_SECRET="****"
-  croc 
+to pipe the code phrase to croc:
+
+  echo **** | croc
 
 Or you can specify the code phrase when you run croc without
 declaring the secret on the command line:
 
-  croc 
+  croc
   Enter receive code: ****
 
-Or you can go back to the classic croc behavior by enabling classic mode:
+Or you can set a code phrase using your environmental variables:
+
+  export CROC_SECRET="****"
+  croc
+
+Or you can go back to the classic croc behavior by enabling classic mode,
+though this can leak the secret via the process name:
 
   croc --classic
 

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -646,7 +646,7 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 	if c.Options.RelayPassword != models.DEFAULT_PASSPHRASE {
 		flags.WriteString("--pass " + c.Options.RelayPassword + " ")
 	}
-	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\n\ncroc %[2]s%[1]s\n", c.Options.SharedSecret, flags.String())
+	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\n\necho %[1]s | croc %[2]s\n", c.Options.SharedSecret, flags.String())
 	if c.Options.Ask {
 		machid, _ := machineid.ID()
 		fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)


### PR DESCRIPTION
Using `echo [secret] | croc` avoids leaking the secret via process name, and is more concise than using an environment variable. (Additionally, exporting an environment variable still has the risk of leaking the secret if the user runs another program )

This pull request changes the cli messages to use this.
I also fixed a typo in the cli error messages.

actually
CROC_SECRET=*** is better i am going to change this