### PR TITLE
Change CLI messages to use CROC_SECRET

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -382,10 +382,9 @@ func send(c *cli.Context) (err error) {
 				fmt.Printf(`On UNIX systems, to send with a custom code phrase, 
 you need to set the environmental variable CROC_SECRET:
 
-  export CROC_SECRET="****"
-  croc send file.txt
+  CROC_SECRET=**** croc send file.txt
 
-Or you can have the code phrase automaticlaly generated:
+Or you can have the code phrase automatically generated:
 
   croc send file.txt
 	
@@ -599,8 +598,7 @@ func receive(c *cli.Context) (err error) {
 			fmt.Printf(`On UNIX systems, to receive with croc you either need 
 to set a code phrase using your environmental variables:
 	
-  export CROC_SECRET="****"
-  croc 
+  CROC_SECRET=**** croc 
 
 Or you can specify the code phrase when you run croc without
 declaring the secret on the command line:

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -646,7 +646,7 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 	if c.Options.RelayPassword != models.DEFAULT_PASSPHRASE {
 		flags.WriteString("--pass " + c.Options.RelayPassword + " ")
 	}
-	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\n\ncroc %[2]s%[1]s\n", c.Options.SharedSecret, flags.String())
+	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\n\nCROC_SECRET=%[1]s croc %[2]s\n", c.Options.SharedSecret, flags.String())
 	if c.Options.Ask {
 		machid, _ := machineid.ID()
 		fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -646,7 +646,7 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 	if c.Options.RelayPassword != models.DEFAULT_PASSPHRASE {
 		flags.WriteString("--pass " + c.Options.RelayPassword + " ")
 	}
-	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\n\nCROC_SECRET=%[1]s croc %[2]s\n", c.Options.SharedSecret, flags.String())
+	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\ncroc %[2]s%[1]s\nif the other computer uses Windows, or\nCROC_SECRET=%[1]s croc %[2]s\notherwise. (UNIX)\n", c.Options.SharedSecret, flags.String())
 	if c.Options.Ask {
 		machid, _ := machineid.ID()
 		fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)


### PR DESCRIPTION
This pull request changes the cli messages to use CROC_SECRET.
Previously, the error message used export CROC_SECRET, which is unnecessary as you can just run `CROC_SECRET=**** croc` in one line.
Also, the messages for the sender used the classic command:
```
On the other computer run

croc ****
```
This made it incompatible with UNIX unless classic mode was activated.

The new command is
```
CROC_SECRET=**** croc
```

I also fixed a typo in the cli error messages.