### PR TITLE
prevent error message before insstalling completion file for non root user

### DIFF
--- a/src/install/default.txt
+++ b/src/install/default.txt
@@ -685,7 +685,7 @@ main() {
     print_message "== Install prefix already exists. No need to create it." "info"
   fi
 
-  [ ! -d "/etc/bash_completion.d/croc" ] && mkdir -p "/etc/bash_completion.d/croc"
+  [ ! -d "${bash_autocomplete_prefix}/croc" ] && mkdir -p "${bash_autocomplete_prefix}/croc" >/dev/null 2>&1
   case "${croc_os}" in
     "Linux" ) install_file_linux "${tmpdir}/${croc_bin_name}" "${prefix}/";
               install_file_rcode="${?}";;


### PR DESCRIPTION
This PR is fixing #564
It just reuse the bash_autocomplete_prefix variable that was not used + it remove the error message in case there is one (for non root user)

:warning: I think that root users will not have the autocomplete install as they will not fail at this stage and the code to install it is now commented. I have not provided a fix for that as I do not know the reason for commenting the auto completion install code few line below my fix