### PR TITLE
fix test case name

### DIFF
--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -232,7 +232,7 @@ func TestCrocSymlink(t *testing.T) {
 		t.Errorf("symlink transfer failed: %s", err.Error())
 	}
 }
-func testCrocIgnoreGit(t *testing.T) {
+func TestCrocIgnoreGit(t *testing.T) {
 	log.SetLevel("trace")
 	defer os.Remove(".gitignore")
 	time.Sleep(300 * time.Millisecond)


### PR DESCRIPTION
Seems like the test was ignored when running `go test` due to lowercase `test`.

Results of `go test -json ./src/croc/ | jq -s 'map(select(.Test and .Action == "pass")) | length'`
Before: 6
After: 7