### PR TITLE
Show recommended croc commands for both Windows and Linux/OSX

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -392,8 +392,7 @@ func send(c *cli.Context) (err error) {
 				fmt.Printf(`On UNIX systems, to send with a custom code phrase, 
 you need to set the environmental variable CROC_SECRET:
 
-  export CROC_SECRET="****"
-  croc send file.txt
+  CROC_SECRET=**** croc send file.txt
 
 Or you can have the code phrase automatically generated:
 
@@ -609,8 +608,7 @@ func receive(c *cli.Context) (err error) {
 			fmt.Printf(`On UNIX systems, to receive with croc you either need 
 to set a code phrase using your environmental variables:
 	
-  export CROC_SECRET="****"
-  croc 
+  CROC_SECRET=**** croc 
 
 Or you can specify the code phrase when you run croc without
 declaring the secret on the command line:

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -648,7 +648,14 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 	if c.Options.RelayPassword != models.DEFAULT_PASSPHRASE {
 		flags.WriteString("--pass " + c.Options.RelayPassword + " ")
 	}
-	fmt.Fprintf(os.Stderr, "Code is: %[1]s\nOn the other computer run\n\ncroc %[2]s%[1]s\n", c.Options.SharedSecret, flags.String())
+	fmt.Fprintf(os.Stderr, `Code is: %[1]s
+
+On the other computer run:
+(For Windows)
+    croc %[2]s%[1]s
+(For Linux/OSX)
+    CROC_SECRET=%[1]q croc %[2]s
+`, c.Options.SharedSecret, flags.String())
 	if c.Options.Ask {
 		machid, _ := machineid.ID()
 		fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)


### PR DESCRIPTION
Currently `croc send` prints the corresponding command to receive a file. 
However the recommended command for Linux and OSX uses and envvar instead.
This allows to the end user to see a copy-pastable line to receive the file for both environments

See https://github.com/schollz/croc/pull/759

