### PR TITLE
use term.GetSize

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -1698,7 +1698,12 @@ func (c *Client) recipientGetFileReady(finished bool) (err error) {
 	c.Step3RecipientRequestFile = true
 	return
 }
-
+func max(a int, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
 func (c *Client) createEmptyFileAndFinish(fileInfo FileInfo, i int) (err error) {
 	log.Debugf("touching file with folder / name")
 	if !utils.Exists(fileInfo.FolderRemote) {
@@ -1737,6 +1742,7 @@ func (c *Client) createEmptyFileAndFinish(fileInfo FileInfo, i int) (err error) 
 		description = " " + description
 	}
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	width = max(20, width-70)
 	if err != nil {
 		return
 	}
@@ -1923,9 +1929,10 @@ func (c *Client) setBar() {
 	if err != nil {
 		return
 	}
+	width = max(20, width-70)
 	description = strings.TrimSpace(description)
 	if len(description) > width {
-		description = description[:(width-3)] + "..."
+		description = description[:width-3] + "..."
 	}
 	c.bar = progressbar.NewOptions64(
 		c.FilesToTransfer[c.FilesToTransferCurrentNum].Size,

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/term"
 	"golang.org/x/time/rate"
 
 	"github.com/denisbrodbeck/machineid"
@@ -1735,8 +1736,9 @@ func (c *Client) createEmptyFileAndFinish(fileInfo FileInfo, i int) (err error) 
 	} else {
 		description = " " + description
 	}
-	if len(description) > 20 {
-		description = description[:17] + "..."
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if len(description) > width {
+		description = description[:(width-3)] + "..."
 	}
 	c.bar = progressbar.NewOptions64(1,
 		progressbar.OptionOnCompletion(func() {
@@ -1914,8 +1916,10 @@ func (c *Client) setBar() {
 	} else if !c.Options.IsSender {
 		description = " " + description
 	}
-	if len(description) > 20 {
-		description = description[:17] + "..."
+	width, _, _ := term.GetSize(int(os.Stdout.Fd()))
+	description = strings.TrimSpace(description)
+	if len(description) > width {
+		description = description[:(width-3)] + "..."
 	}
 	c.bar = progressbar.NewOptions64(
 		c.FilesToTransfer[c.FilesToTransferCurrentNum].Size,

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -1737,6 +1737,9 @@ func (c *Client) createEmptyFileAndFinish(fileInfo FileInfo, i int) (err error) 
 		description = " " + description
 	}
 	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return
+	}
 	if len(description) > width {
 		description = description[:(width-3)] + "..."
 	}
@@ -1916,7 +1919,10 @@ func (c *Client) setBar() {
 	} else if !c.Options.IsSender {
 		description = " " + description
 	}
-	width, _, _ := term.GetSize(int(os.Stdout.Fd()))
+	width, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return
+	}
 	description = strings.TrimSpace(description)
 	if len(description) > width {
 		description = description[:(width-3)] + "..."


### PR DESCRIPTION
fix #787 

now for medium length, it won't truncate file name.

```
Enter receive code: 4770-citizen-valid-speed
Accept '[Reaktor] Millennium Actress - Sennen Joyuu [1080p][x265][10-bit][Dual-Audio].mkv' (1.3 GB)? (Y/n) 

Receiving (<-127.0.0.1:38286)
[Reaktor] Millennium Actress - Sennen Joyuu [1080p][x265][10-bit][Dual-Audio].mkv  18% |███                 | (255 MB/1.4 GB, 74 MB/s) [3s:15s]^C⏎           
```

