### PR TITLE
Improve clipboard copy

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -2129,7 +2129,7 @@ func copyToClipboard(str string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "windows":
-		cmd = exec.Command("cmd", "/c", "clip")
+		cmd = exec.Command("clip")
 	case "darwin":
 		cmd = exec.Command("pbcopy")
 	case "linux":

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -2133,7 +2133,11 @@ func copyToClipboard(str string) {
 	case "darwin":
 		cmd = exec.Command("pbcopy")
 	case "linux":
-		cmd = exec.Command("xclip", "-selection", "clipboard")
+		if os.Getenv("XDG_SESSION_TYPE") == "wayland" {
+			cmd = exec.Command("wl-copy")
+		} else {
+			cmd = exec.Command("xclip", "-selection", "clipboard")
+		}
 	default:
 		return
 	}


### PR DESCRIPTION
A couple of small modifications to the new clipboard-copy function:
- Don't use `cmd` to run `clip` on Windows (it's not an internal command).
- Add Wayland support on Linux (by using `wl-copy` after checking `$XDG_SESSION_TYPE`).