### PR TITLE
Mask password in logs

### DIFF
--- a/src/tcp/tcp.go
+++ b/src/tcp/tcp.go
@@ -76,7 +76,17 @@ func Run(debugLevel, host, port, password string, banner ...string) (err error) 
 
 func (s *server) start() (err error) {
 	log.SetLevel(s.debugLevel)
-	log.Debugf("starting with password '%s'", s.password)
+
+	// Mask our password in logs
+	maskedPassword := ""
+	if len(s.password) > 2 {
+		maskedPassword = fmt.Sprintf("%c***%c", s.password[0], s.password[len(s.password)-1])
+	} else {
+		maskedPassword = s.password
+	}
+
+	log.Debugf("starting with password '%s'", maskedPassword)
+
 	s.rooms.Lock()
 	s.rooms.rooms = make(map[string]roomInfo)
 	s.rooms.Unlock()


### PR DESCRIPTION
I am opening this PR to illustrate an issue.

Passwords should not be written in plaintext to logs, even in debug mode.  By masking the password, we can keep it safer and still provide ourselves a way to confirm the value is what we expect.

Some examples of what this will look like in logs:

password -> appearance in logs

```
- secretpass -> s***s
- pass123 -> p***3
- 123 -> 1***3
- pw -> pw
- p -> p
```

A minimum password length of 3 would make this even better.