### PR TITLE
Add a qrcode flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/tscholl2/siec v0.0.0-20240310163802-c2c6f6198406 // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/schollz/peerdiscovery v1.7.5/go.mod h1:Crht2FOfD1/eL3U/AIM0vvwVZDPePl
 github.com/schollz/progressbar/v3 v3.17.1 h1:bI1MTaoQO+v5kzklBjYNRQLoVpe0zbyRZNK6DFkVC5U=
 github.com/schollz/progressbar/v3 v3.17.1/go.mod h1:RzqpnsPQNjUyIgdglUjRLgD7sVnxN1wpmBMV+UiEbL4=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -77,6 +77,7 @@ func Run() (err error) {
 				&cli.BoolFlag{Name: "git", Usage: "enable .gitignore respect / don't send ignored files"},
 				&cli.IntFlag{Name: "port", Value: 9009, Usage: "base port for the relay"},
 				&cli.IntFlag{Name: "transfers", Value: 4, Usage: "number of ports to use for transfers"},
+				&cli.BoolFlag{Name: "qrcode", Aliases: []string{"qr"}, Usage: "show receive code as a qrcode"},
 			},
 			HelpName: "croc send",
 			Action:   send,
@@ -302,6 +303,7 @@ func send(c *cli.Context) (err error) {
 		ThrottleUpload:   c.String("throttleUpload"),
 		ZipFolder:        c.Bool("zip"),
 		GitIgnore:        c.Bool("git"),
+		ShowQrCode:       c.Bool("qrcode"),
 		MulticastAddress: c.String("multicast"),
 	}
 	if crocOptions.RelayAddress != models.DEFAULT_RELAY {

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -27,6 +27,7 @@ import (
 	"github.com/schollz/pake/v3"
 	"github.com/schollz/peerdiscovery"
 	"github.com/schollz/progressbar/v3"
+	"github.com/skip2/go-qrcode"
 	"golang.org/x/term"
 	"golang.org/x/time/rate"
 
@@ -85,6 +86,7 @@ type Options struct {
 	TestFlag         bool
 	GitIgnore        bool
 	MulticastAddress string
+	ShowQrCode       bool
 }
 
 type SimpleMessage struct {
@@ -660,6 +662,9 @@ On the other computer run:
     CROC_SECRET=%[1]q croc %[2]s
 `, c.Options.SharedSecret, flags.String())
 	copyToClipboard(c.Options.SharedSecret)
+	if c.Options.ShowQrCode {
+		showReceiveCommandQrCode(fmt.Sprintf("%[1]s", c.Options.SharedSecret))
+	}
 	if c.Options.Ask {
 		machid, _ := machineid.ID()
 		fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)
@@ -830,6 +835,13 @@ On the other computer run:
 		err = <-errchan
 	}
 	return err
+}
+
+func showReceiveCommandQrCode(command string) {
+	qrCode, err := qrcode.New(command, qrcode.Medium)
+	if err == nil {
+		fmt.Println(qrCode.ToSmallString(false))
+	}
 }
 
 // Receive will receive a file
@@ -2146,5 +2158,5 @@ func copyToClipboard(str string) {
 		log.Debugf("error copying to clipboard: %v", err)
 		return
 	}
-	fmt.Fprintf(os.Stderr, "Code copied to clipboard")
+	fmt.Fprintf(os.Stderr, "Code copied to clipboard\n")
 }


### PR DESCRIPTION
- Introduces a new flag which allows displaying the receive command using a qr code.
- Adds a newline after the message indicating that the code was copied to the clipboard.

This is an exact copy of the feature introduced in https://github.com/schollz/croc/pull/591, which went stale. The only addition is a newline.

![image](https://github.com/user-attachments/assets/fa2ec9f7-1aa1-4dd6-81d2-b9b47d05e343)
