### PR TITLE
Abort sending when message authentication fails

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -753,6 +753,12 @@ On the other computer run:
 					dataDecrypt, decryptErr = crypt.Decrypt(data, kB)
 					if decryptErr != nil {
 						log.Tracef("error decrypting: %v: '%s'", decryptErr, data)
+						// relay sent a messag encrypted with an invalid key.
+						// consider this a security issue and abort
+						if strings.Contains(decryptErr.Error(), "message authentication failed") {
+							errchan <- decryptErr
+							return
+						}
 					} else {
 						// copy dataDecrypt to data
 						data = dataDecrypt
@@ -839,7 +845,7 @@ On the other computer run:
 		}
 	}
 	if !c.Options.DisableLocal {
-		if strings.Contains(err.Error(), "refusing files") || strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "bad password") {
+		if strings.Contains(err.Error(), "refusing files") || strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "bad password") || strings.Contains(err.Error(), "message authentication failed") {
 			errchan <- err
 		}
 		err = <-errchan


### PR DESCRIPTION
This either means that the TCP connection did not use the proper key to encrypt (which should never happen when running properly) or the receiver wrote a key which starts with the same 4 characters, but does not match the sender's code. If the latter, regardless if the user attempts to read the message by correcting the key, it will always receive an error after the first failure. However, the sender will not be closed, making it difficult to detect what happened and why the transfer does not succeed. This change also forces the sender to close when the receiver uses a key that starts with the same characters, but is a different one

Let me know if you're not aware about this error, I can make a quick recording to show how it looks like when reproduced.