### PR TITLE
feat: a better clipboard, a simple TCP healthcheck and fixed docker deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,5 +45,5 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm,linux/arm64,linux/386
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,9 @@
 go.work
 go.work.sum
 
-# env file
+# Environment variables file
 .env
+
+# Croc builds
+/croc
+croc_v*

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,9 @@ COPY --from=builder /go/croc/croc /go/croc/croc-entrypoint.sh /
 
 USER nobody
 
+# Simple TCP health check with nc!
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD nc -z localhost 9009 || exit 1
+
 ENTRYPOINT ["/croc-entrypoint.sh"]
 CMD ["relay"]

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.18.0
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/stretchr/testify v1.11.1
+	golang.design/x/clipboard v0.7.1
 	golang.org/x/crypto v0.42.0
 	golang.org/x/net v0.44.0
 	golang.org/x/sys v0.36.0
@@ -34,5 +35,8 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/tscholl2/siec v0.0.0-20240310163802-c2c6f6198406 // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect
+	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
+	golang.org/x/image v0.28.0 // indirect
+	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq
 github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+golang.design/x/clipboard v0.7.1 h1:OEG3CmcYRBNnRwpDp7+uWLiZi3hrMRJpE9JkkkYtz2c=
+golang.design/x/clipboard v0.7.1/go.mod h1:i5SiIqj0wLFw9P/1D7vfILFK0KHMk7ydE72HRrUIgkg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
@@ -70,6 +72,12 @@ golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
 golang.org/x/crypto v0.42.0 h1:chiH31gIWm57EkTXpwnqf8qeuMUi0yekh6mT2AvFlqI=
 golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix8=
+golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 h1:Wdx0vgH5Wgsw+lF//LJKmWOJBLWX6nprsMqnf99rYDE=
+golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476/go.mod h1:ygj7T6vSGhhm/9yTpOQQNvuAUFziTH7RUiH74EoE2C8=
+golang.org/x/image v0.28.0 h1:gdem5JW1OLS4FbkWgLO+7ZeFzYtL3xClb97GaUzYMFE=
+golang.org/x/image v0.28.0/go.mod h1:GUJYXtnGKEUgggyzh+Vxt+AviiCcyiwpsl8iQ8MvwGY=
+golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f h1:/n+PL2HlfqeSiDCuhdBbRNlGS/g2fM4OHufalHaTVG8=
+golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f/go.mod h1:ESkJ836Z6LpG6mTVAhA48LpfW/8fNR0ifStlH2axyfg=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	}()
 
 	// Wait for a termination signal
-	_ = <-sigs
+	<-sigs
 	utils.RemoveMarkedFiles()
 
 	// Exit the program gracefully

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -119,7 +119,7 @@ func Run() (err error) {
 		&cli.StringFlag{Name: "pass", Value: models.DEFAULT_PASSPHRASE, Usage: "password for the relay", EnvVars: []string{"CROC_PASS"}},
 		&cli.StringFlag{Name: "socks5", Value: "", Usage: "add a socks5 proxy", EnvVars: []string{"SOCKS5_PROXY"}},
 		&cli.StringFlag{Name: "connect", Value: "", Usage: "add a http proxy", EnvVars: []string{"HTTP_PROXY"}},
-		&cli.StringFlag{Name: "throttleUpload", Value: "", Usage: "Throttle the upload speed e.g. 500k"},
+		&cli.StringFlag{Name: "throttleUpload", Value: "", Usage: "throttle the upload speed e.g. 500k"},
 	}
 	app.EnableBashCompletion = true
 	app.HideHelp = false
@@ -478,9 +478,7 @@ Or you can go back to the classic croc behavior by enabling classic mode:
 
 	// save the config
 	saveConfig(c, crocOptions)
-
 	err = cr.Send(minimalFileInfos, emptyFoldersToTransfer, totalNumberFolders)
-
 	return
 }
 

--- a/src/comm/comm.go
+++ b/src/comm/comm.go
@@ -142,7 +142,9 @@ func (c *Comm) Read() (buf []byte, numBytes int, bs []byte, err error) {
 		log.Warnf("error setting read deadline: %v", err)
 	}
 	// must clear the timeout setting
-	defer c.connection.SetDeadline(time.Time{})
+	if err := c.connection.SetDeadline(time.Time{}); err != nil {
+		log.Warnf("failed to clear deadline: %v", err)
+	}
 
 	// read until we get 4 bytes for the magic
 	header := make([]byte, 4)

--- a/src/install/updateversion.go
+++ b/src/install/updateversion.go
@@ -46,7 +46,7 @@ func replaceInFile(fname, start, end, replacement string) (err error) {
 	if err != nil {
 		return
 	}
-	oldVersion := GetStringInBetween(string(b), start, end)
+	oldVersion := getStringInBetween(string(b), start, end)
 	if oldVersion == "" {
 		err = fmt.Errorf("nothing")
 		return
@@ -61,8 +61,8 @@ func replaceInFile(fname, start, end, replacement string) (err error) {
 	return
 }
 
-// GetStringInBetween Returns empty string if no start string found
-func GetStringInBetween(str string, start string, end string) (result string) {
+// getStringInBetween Returns empty string if no start string found
+func getStringInBetween(str, start, end string) (result string) {
 	s := strings.Index(str, start)
 	if s == -1 {
 		return

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -281,11 +281,12 @@ func LocalIP() string {
 	return localAddr.IP.String()
 }
 
+// GenerateRandomPin returns a randomly generated pin with set lenght
 func GenerateRandomPin() string {
 	s := ""
 	max := new(big.Int)
 	max.SetInt64(9)
-	for i := 0; i < NbPinNumbers; i++ {
+	for range NbPinNumbers {
 		v, err := rand.Int(rand.Reader, max)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
This should fix #969 so it can be merged.
It was undone as it failed a CI test and prevented the builds to be statically compiled.
My guess, it was a problem with the versioning as everything works locally for me.
The builds in ci.yml all compile statically for me and the tests pass.
See if this fixes it! (also synced)
A possible issue might be the Android/IOS clipboard as it might require an extra [dependency](https://github.com/golang-design/clipboard?tab=readme-ov-file#dependency), but I don't think that is the case!