### PR TITLE
Abort sending when message authentication fails

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -745,6 +745,12 @@ On the other computer run:
 					dataDecrypt, decryptErr = crypt.Decrypt(data, kB)
 					if decryptErr != nil {
 						log.Tracef("error decrypting: %v: '%s'", decryptErr, data)
+						// relay sent a messag encrypted with an invalid key.
+						// consider this a security issue and abort
+						if strings.Contains(decryptErr.Error(), "message authentication failed") {
+							errchan <- decryptErr
+							return
+						}
 					} else {
 						// copy dataDecrypt to data
 						data = dataDecrypt
@@ -830,7 +836,7 @@ On the other computer run:
 		}
 	}
 	if !c.Options.DisableLocal {
-		if strings.Contains(err.Error(), "refusing files") || strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "bad password") {
+		if strings.Contains(err.Error(), "refusing files") || strings.Contains(err.Error(), "EOF") || strings.Contains(err.Error(), "bad password") || strings.Contains(err.Error(), "message authentication failed") {
 			errchan <- err
 		}
 		err = <-errchan


### PR DESCRIPTION
Note: I'm reopening this PR in case you missed it [last time](https://github.com/schollz/croc/pull/923). Let me know if there was something wrong with the previous one. I also realized that maybe the problem this was solving is not clear, I attached a video now that shows the previous bug still exists on main.

This either means that the TCP connection did not use the proper key to encrypt (which should never happen when running properly) or the receiver wrote a key which starts with the same 4 characters, but does not match the sender's code. If the latter, regardless if the user attempts to read the message by correcting the key, it will always receive an error after the first failure. However, the sender will not be closed, making it difficult to detect what happened and why the transfer does not succeed. This change also closes the sender when the receiver uses a key that starts with the same characters, but is a different one.

In the video, note that a mistype will let the sender open, even though the receiver can no longer receive the message.


https://github.com/user-attachments/assets/e83742db-aa87-463a-a9b3-5532224fe416

