### PR TITLE
Fix regex pattern for Windows installers

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -14,5 +14,6 @@ jobs:
         uses: vedantmgoyal9/winget-releaser@v2
         with:
           identifier: schollz.croc
-          installers-regex: '_Windows-\w+\.zip$'
+          installers-regex: '.*Windows.*\.zip$'
           token: ${{ secrets.WINGET_TOKEN }}
+


### PR DESCRIPTION
Updated regex pattern for installers in Winget workflow.

Should match croc_v10.2.7_Windows-64bit.zip via `.*Windows.*\.zip$`

Should fix https://github.com/schollz/croc/issues/826