### PR TITLE
Fix source comment typos

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -762,7 +762,7 @@ On the other computer run:
 					dataDecrypt, decryptErr = crypt.Decrypt(data, kB)
 					if decryptErr != nil {
 						log.Tracef("error decrypting: %v: '%s'", decryptErr, data)
-						// relay sent a messag encrypted with an invalid key.
+						// relay sent a message encrypted with an invalid key.
 						// consider this a security issue and abort
 						if strings.Contains(decryptErr.Error(), "message authentication failed") {
 							errchan <- decryptErr

--- a/src/mnemonicode/mnemonicode.go
+++ b/src/mnemonicode/mnemonicode.go
@@ -44,7 +44,7 @@ func WordsRequired(length int) int {
 
 // EncodeWordList encodes src into mnemomic words which are appended to dst.
 // The final wordlist is returned.
-// There will be WordsRequired(len(src)) words appeneded.
+// There will be WordsRequired(len(src)) words appended.
 func EncodeWordList(dst []string, src []byte) (result []string) {
 	if n := len(dst) + WordsRequired(len(src)); cap(dst) < n {
 		result = make([]string, len(dst), n)

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -281,7 +281,7 @@ func LocalIP() string {
 	return localAddr.IP.String()
 }
 
-// GenerateRandomPin returns a randomly generated pin with set lenght
+// GenerateRandomPin returns a randomly generated pin with set length
 func GenerateRandomPin() string {
 	s := ""
 	max := new(big.Int)


### PR DESCRIPTION
Fixes some misc. source comment typos.

Found via: `codespell -L flate`