### PR TITLE
For peer-to-peer connectivity within a LAN, the sender and receiver d…

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -60,36 +60,36 @@ func Debug(debug bool) {
 
 // Options specifies user specific options
 type Options struct {
-	IsSender         bool
-	SharedSecret     string
-	RoomName         string
-	Debug            bool
-	RelayAddress     string
-	RelayAddress6    string
-	RelayPorts       []string
-	RelayPassword    string
-	Stdout           bool
-	NoPrompt         bool
-	NoMultiplexing   bool
-	DisableLocal     bool
-	OnlyLocal        bool
-	IgnoreStdin      bool
-	Ask              bool
-	SendingText      bool
-	NoCompress       bool
-	IP               string
-	Overwrite        bool
-	Curve            string
-	HashAlgorithm    string
-	ThrottleUpload   string
-	ZipFolder        bool
-	TestFlag         bool
-	GitIgnore        bool
-	MulticastAddress string
-	ShowQrCode       bool
-	Exclude          []string
-	Quiet            bool
-	DisableClipboard bool
+	IsSender          bool
+	SharedSecret      string
+	RoomName          string
+	Debug             bool
+	RelayAddress      string
+	RelayAddress6     string
+	RelayPorts        []string
+	RelayPassword     string
+	Stdout            bool
+	NoPrompt          bool
+	NoMultiplexing    bool
+	DisableLocal      bool
+	OnlyLocal         bool
+	IgnoreStdin       bool
+	Ask               bool
+	SendingText       bool
+	NoCompress        bool
+	IP                string
+	Overwrite         bool
+	Curve             string
+	HashAlgorithm     string
+	ThrottleUpload    string
+	ZipFolder         bool
+	TestFlag          bool
+	GitIgnore         bool
+	MulticastAddress  string
+	ShowQrCode        bool
+	Exclude           []string
+	Quiet             bool
+	DisableClipboard  bool
 	ExtendedClipboard bool
 }
 
@@ -1069,21 +1069,28 @@ func (c *Client) Receive() (err error) {
 			for _, ip := range ips {
 				ipv4Addr, ipv4Net, errNet := net.ParseCIDR(fmt.Sprintf("%s/24", ip))
 				log.Debugf("ipv4Add4: %+v, ipv4Net: %+v, err: %+v", ipv4Addr, ipv4Net, errNet)
-				localIps, _ := utils.GetLocalIPs()
-				haveLocalIP := false
-				for _, localIP := range localIps {
-					localIPparsed := net.ParseIP(localIP)
-					log.Debugf("localIP: %+v, localIPparsed: %+v", localIP, localIPparsed)
-					if ipv4Net.Contains(localIPparsed) {
-						haveLocalIP = true
-						log.Debugf("ip: %+v is a local IP", ip)
-						break
-					}
-				}
-				if !haveLocalIP {
-					log.Debugf("%s is not a local IP, skipping", ip)
-					continue
-				}
+
+				// For peer-to-peer connectivity within a LAN, the sender and receiver don't need to be on the same subnet.
+				// Even with NAT routers in their respective local networks,
+				// a receiver behind NAT can establish direct access to the sender without requiring internet connectivity.
+				// Conversely, the local networks on the sender and receiver may overlap but not be connected.
+				// This often occurs with 192.168.0.0/30 and 192.168.1.0/30 subnets.
+
+				// localIps, _ := utils.GetLocalIPs()
+				// haveLocalIP := false
+				// for _, localIP := range localIps {
+				// 	localIPparsed := net.ParseIP(localIP)
+				// 	log.Debugf("localIP: %+v, localIPparsed: %+v", localIP, localIPparsed)
+				// 	if ipv4Net.Contains(localIPparsed) {
+				// 		haveLocalIP = true
+				// 		log.Debugf("ip: %+v is a local IP", ip)
+				// 		break
+				// 	}
+				// }
+				// if !haveLocalIP {
+				// 	log.Debugf("%s is not a local IP, skipping", ip)
+				// 	continue
+				// }
 
 				serverTry := net.JoinHostPort(ip, port)
 				conn, banner2, externalIP, errConn := tcp.ConnectToTCPServer(serverTry, c.Options.RelayPassword, c.Options.RoomName, 500*time.Millisecond)


### PR DESCRIPTION
…on't need to be on the same subnet.

Even with NAT routers in their respective local networks, a receiver behind NAT can establish direct access to the sender without requiring internet connectivity. Conversely, the local networks on the sender and receiver may overlap but not be connected. This often occurs with 192.168.0.0/24 and 192.168.1.0/24 subnets.

Please look:
`---before   
[debug]	11:31:12 croc.go:1059: ips data: ["9009","x.y.z.189","192.168.0.189"]
[debug]	11:31:12 croc.go:1071: ipv4Add4: x.y.z.189, ipv4Net: x.y.z.0/24, err: <nil>
[debug]	11:31:12 croc.go:1076: localIP: 192.168.0.12, localIPparsed: 192.168.0.12
[debug]	11:31:12 croc.go:1076: localIP: 172.17.0.1, localIPparsed: 172.17.0.1
[debug]	11:31:12 croc.go:1084: x.y.z.189 is not a local IP, skipping
[debug]	11:31:12 croc.go:1079: ip: 192.168.0.189 is a local IP
[debug]	11:31:12 comm.go:78: dialing to 192.168.0.189:9009 with timelimit 500ms
[debug]	11:31:13 comm.go:83: comm.NewConnection failed: dial tcp 192.168.0.189:9009: i/o timeout
[debug]	11:31:13 tcp.go:493: comm.NewConnection failed: dial tcp 192.168.0.189:9009: i/o timeout
[debug]	11:31:13 croc.go:1091: comm.NewConnection failed: dial tcp 192.168.0.189:9009: i/o timeout
[debug]	11:31:13 croc.go:1092: could not connect to 192.168.0.189:9009

---after
[debug]	15:41:14 croc.go:1047: sending ips?
[debug]	15:41:14 croc.go:1059: ips data: ["9009","x.y.z.189","192.168.0.189"]
[debug]	15:41:14 croc.go:1071: ipv4Add4: x.y.z.189, ipv4Net: x.y.z.0/24, err: <nil>
[debug]	15:41:14 comm.go:78: dialing to x.y.z.189:9009 with timelimit 500ms
[debug]	15:41:14 comm.go:87: connected to 'x.y.z.189:9009'
[debug]	15:41:14 tcp.go:523: strong key: e56b5ac21f926e52b551385f81f89ed709151e3cddfd1de61a9ddbc31fa324ff
[debug]	15:41:14 tcp.go:537: sending password
[debug]	15:41:14 tcp.go:548: waiting for first ok
[debug]	15:41:14 tcp.go:566: sending room; 420d6ae6859531b625e93e6aac0c26316b3f2ba83358af048f6c71607325e4ad
[debug]	15:41:14 tcp.go:577: waiting for room confirmation
[debug]	15:41:14 tcp.go:593: all set
[debug]	15:41:14 croc.go:1100: local connection established to x.y.z.189:9009
[debug]	15:41:14 croc.go:1101: banner: 9010,9011,9012
`