### PR TITLE
fix(docs): add docker.io prefix for podman compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ conda install --channel conda-forge croc
 Add the following one-liner function to your ~/.profile (works with any POSIX-compliant shell):
 
 ```bash
-croc() { [ $# -eq 0 ] && set -- ""; docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/c" -v "$HOME/.config/croc:/.config/croc" -w /c -e CROC_SECRET schollz/croc "$@"; }
+croc() { [ $# -eq 0 ] && set -- ""; mkdir -p "$HOME/.config/croc"; docker run --rm -it --user "$(id -u):$(id -g)" -v "$(pwd):/c" -v "$HOME/.config/croc:/.config/croc" -w /c -e CROC_SECRET docker.io/schollz/croc "$@"; }
 ```
 
 You can also just paste it in the terminal for current session. On first run Docker will pull the image. `croc` via Docker will only work within the current directory and its subdirectories.
@@ -317,7 +317,7 @@ croc --relay "myrelay.example.com:9009" send [filename]
 You can also run a relay with Docker:
 
 ```bash
-docker run -d -p 9009-9013:9009-9013 -e CROC_PASS='YOURPASSWORD' schollz/croc
+docker run -d -p 9009-9013:9009-9013 -e CROC_PASS='YOURPASSWORD' docker.io/schollz/croc
 ```
 
 To send files using your custom relay:


### PR DESCRIPTION
Fixes #1013

## Changes
- Add `docker.io/` prefix to Docker image names for podman-docker compatibility
- - Add `mkdir -p` command to create `.config/croc` directory before mounting volume
## Problem
On systems with podman-docker (Ubuntu 24.04+), the short image name `schollz/croc` fails with:
```
Error: short-name "schollz/croc" did not resolve to an alias
```

## Solution
Use fully qualified image name `docker.io/schollz/croc` and ensure config directory exists before mounting.

## Testing
Tested with podman-docker on Ubuntu 24.04
