### PR TITLE
Context support for GUI-driven clients and relays

### DIFF
--- a/plans/relay-room-auth.md
+++ b/plans/relay-room-auth.md
@@ -1,0 +1,112 @@
+# Plan: Two-level relay authorization in croc
+
+## Problem
+
+When sender CS1 runs relay CR with password CRP and sends a file to recipient CR1, the receive command includes `--pass CRP`. Recipient CR1 learns the relay password and can:
+- Create new rooms on the relay
+- Send files to others through the relay without CS1's permission
+
+## Solution: Modify ONLY the relay
+
+**The client side does NOT change.** All logic is on the relay side.
+
+```mermaid
+flowchart TD
+    A[Client connects to relay] --> B[PAKE handshake]
+    B --> C[Client sends password]
+    C --> D{Password matches?}
+    D -->|Yes| E[Full access - as before]
+    E --> F[Send banner]
+    F --> G[Receive room name]
+    G --> H[Create or join room]
+    D -->|No| I[Restricted access]
+    I --> J[Send banner - instead of error]
+    J --> K[Receive room name]
+    K --> L{Room exists?}
+    L -->|Yes| M[Join room]
+    L -->|No| N[Reply bad password - reject]
+```
+
+### Backward compatibility
+
+| Scenario | Client password | Relay password | Behavior |
+|----------|----------------|----------------|----------|
+| Public relay | pass123 | pass123 | ✅ Full access - as before |
+| Custom relay, sender | CRP | CRP | ✅ Full access - as before |
+| Custom relay, recipient with --pass CRP | CRP | CRP | ✅ Full access - as before |
+| Custom relay, recipient without --pass | pass123 | CRP | ✅ Restricted: can join existing room |
+| Custom relay, attacker without password | pass123 | CRP | ❌ Cannot create room - bad password |
+| New relay + old client | any | any | ✅ Works - client unchanged |
+| Old relay + new client | pass123 | CRP | ❌ Old relay replies bad password immediately - need to update relay |
+
+## Changes in `src/tcp/tcp.go`
+
+### Function `clientCommunication`
+
+**Current logic**: When password doesn't match, immediately send error and close connection:
+```go
+if strings.TrimSpace(string(passwordBytes)) != s.password {
+    err = fmt.Errorf("bad password")
+    enc, _ := crypt.Encrypt([]byte(err.Error()), strongKeyForEncryption)
+    if err = c.Send(enc); err != nil {
+        return "", fmt.Errorf("send error: %w", err)
+    }
+    return
+}
+```
+
+**New logic**: When password doesn't match, don't reject immediately — set a flag and continue:
+
+```go
+passwordMatch := strings.TrimSpace(string(passwordBytes)) == s.password
+
+// Send banner regardless of password match
+banner := s.banner
+if len(banner) == 0 {
+    banner = "ok"
+}
+bSend, err := crypt.Encrypt([]byte(banner+"|||"+c.Connection().RemoteAddr().String()), strongKeyForEncryption)
+// ... send banner ...
+
+// Receive room name from client
+enc, err := c.Receive()
+roomBytes, err := crypt.Decrypt(enc, strongKeyForEncryption)
+room = string(roomBytes)
+
+s.rooms.Lock()
+if _, ok := s.rooms.rooms[room]; !ok {
+    // Room does NOT exist
+    if !passwordMatch {
+        // Restricted access: cannot create rooms
+        s.rooms.Unlock()
+        bSend, _ = crypt.Encrypt([]byte("bad password"), strongKeyForEncryption)
+        c.Send(bSend)
+        return "", fmt.Errorf("bad password")
+    }
+    // Full access: create room (as before)
+    s.rooms.rooms[room] = roomInfo{first: c, opened: time.Now()}
+    // ... send ok ...
+    return
+}
+// Room exists — allow joining regardless of password
+// ... existing join logic ...
+```
+
+### Summary of changes in `clientCommunication`:
+
+1. Replace the `if != password { return }` block with setting a `passwordMatch` flag
+2. Banner is sent always — remove dependency on password check
+3. After receiving room name — add check: if room is new AND password didn't match → reject with `bad password`
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src/tcp/tcp.go` | Modify `clientCommunication` — allow joining existing room with default password |
+
+## Tests to add in `src/tcp/tcp_test.go`
+
+1. Sender with correct password → can create room ✅
+2. Recipient with default password + existing room → can join ✅
+3. Client with default password + non-existing room → rejected ❌
+4. Public relay (pass123) → everything works as before ✅

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -535,7 +535,7 @@ func (c *Client) sendCollectFiles(filesInfo []FileInfo) (err error) {
 			c.Options.HashAlgorithm = "xxhash"
 		}
 
-		c.FilesToTransfer[i].Hash, err = utils.HashFile(fullPath, c.Options.HashAlgorithm, fileInfo.Size > 1e7)
+		c.FilesToTransfer[i].Hash, err = c.stop.hash(fullPath, c.Options.HashAlgorithm, fileInfo.Size > 1e7)
 		log.Debugf("hashed %s to %x using %s", fullPath, c.FilesToTransfer[i].Hash, c.Options.HashAlgorithm)
 		totalFilesSize += fileInfo.Size
 		if err != nil {

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -1654,6 +1654,15 @@ func (c *Client) processMessage(payload []byte) (done bool, err error) {
 
 func (c *Client) updateIfSenderChannelSecured() (err error) {
 	if c.Options.IsSender && c.Step1ChannelSecured && !c.Step2FileInfoTransferred {
+
+		if len(c.FilesToTransfer) == 1 &&
+			c.FilesToTransfer[0].Name == filepath.Base(os.DevNull) &&
+			c.FilesToTransfer[0].FolderSource == filepath.Dir(os.DevNull) {
+			log.Debug(os.DevNull)
+			c.Step2FileInfoTransferred = true
+			return
+		}
+
 		var b []byte
 		machID, _ := machineid.ID()
 		b, err = json.Marshal(SenderInfo{

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -1515,7 +1515,8 @@ func (c *Client) processMessagePake(m message.Message) (err error) {
 				fmt.Sprintf("%s-%d", c.Options.RoomName, j),
 			)
 			if err != nil {
-				panic(err)
+				log.Errorf("failed to connect to %s: %v", server, err)
+				return
 			}
 			log.Debugf("connected to %s", server)
 			if !c.Options.IsSender {

--- a/src/croc/ctx.go
+++ b/src/croc/ctx.go
@@ -1,0 +1,98 @@
+// ctx.go
+package croc
+
+import (
+	"context"
+	"time"
+
+	"github.com/schollz/croc/v10/src/message"
+	"github.com/schollz/croc/v10/src/tcp"
+	log "github.com/schollz/logger"
+)
+
+// stop manages graceful shutdown
+type stop struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	stopChan chan struct{} //peerdiscovery
+	run      func(debugLevel string, host string, port string, password string, banner ...string) (err error)
+	gui      bool
+}
+
+// newStop creates a new stop manager instance
+func newStop(ctx context.Context) *stop {
+	s := &stop{
+		stopChan: make(chan struct{}),
+		run:      tcp.Run,
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.ctx, s.cancel = context.WithCancel(ctx)
+
+	return s
+}
+
+func (s *stop) done() {
+	<-s.ctx.Done()
+	time.Sleep(time.Millisecond)
+	close(s.stopChan)
+	log.Trace("croc done")
+}
+
+// NewCtx creates a client with context support
+func NewCtx(ctx context.Context, ops Options) (*Client, error) {
+	// Create a regular c
+	c, err := New(ops)
+	if err != nil {
+		return nil, err
+	}
+	c.stop = newStop(ctx)
+	c.stop.gui = true
+	c.stop.run = func(debugLevel string, host string, port string, password string, banner ...string) (err error) {
+		return tcp.RunCtx(c.stop.ctx, debugLevel, host, port, password, banner...)
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			log.Trace("parent context canceled")
+			c.SendError()
+		case <-c.stopChan:
+			// for stop goroutine
+		}
+		log.Trace("croc NewCtx done")
+	}()
+
+	return c, nil
+}
+
+// ctxErr checks whether it is necessary to interrupt my loops and goroutines
+func (s *stop) ctxErr() error {
+	select {
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	default:
+		return nil
+	}
+}
+
+// Cancel initiates interruption of my loops and goroutines
+func (s *stop) Cancel() {
+	log.Trace("croc Cancel")
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+}
+
+// SendError tells the peer to interrupt their loops and goroutines
+func (c *Client) SendError() {
+	if c.Key != nil && len(c.conn) > 0 && c.conn[0] != nil {
+		message.Send(c.conn[0], c.Key, message.Message{
+			Type:    message.TypeError,
+			Message: "refusing files",
+		})
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/src/croc/ctx.go
+++ b/src/croc/ctx.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/schollz/croc/v10/src/message"
 	"github.com/schollz/croc/v10/src/tcp"
+	"github.com/schollz/croc/v10/src/utils"
 	log "github.com/schollz/logger"
 )
 
@@ -16,6 +17,7 @@ type stop struct {
 	cancel   context.CancelFunc
 	stopChan chan struct{} //peerdiscovery
 	run      func(debugLevel string, host string, port string, password string, banner ...string) (err error)
+	hash     func(fname string, algorithm string, showProgress ...bool) (hash256 []byte, err error)
 	gui      bool
 }
 
@@ -24,6 +26,7 @@ func newStop(ctx context.Context) *stop {
 	s := &stop{
 		stopChan: make(chan struct{}),
 		run:      tcp.Run,
+		hash:     utils.HashFile,
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -51,6 +54,9 @@ func NewCtx(ctx context.Context, ops Options) (*Client, error) {
 	c.stop.gui = true
 	c.stop.run = func(debugLevel string, host string, port string, password string, banner ...string) (err error) {
 		return tcp.RunCtx(c.stop.ctx, debugLevel, host, port, password, banner...)
+	}
+	c.stop.hash = func(fname string, algorithm string, showProgress ...bool) (hash256 []byte, err error) {
+		return utils.HashFileCtx(c.stop.ctx, fname, algorithm, showProgress...)
 	}
 
 	go func() {

--- a/src/tcp/ctx.go
+++ b/src/tcp/ctx.go
@@ -1,0 +1,69 @@
+// ctx.go
+package tcp
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+
+	log "github.com/schollz/logger"
+)
+
+// stop manages graceful shutdown of the TCP server
+type stop struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	// Track connections
+	server net.Listener
+	wg     sync.WaitGroup
+	gui    bool
+}
+
+// newStop creates a new stop manager
+func newStop(ctx context.Context) *stop {
+	s := &stop{}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	s.ctx, s.cancel = context.WithCancel(ctx)
+
+	return s
+}
+
+// Cancel initiate graceful shutdown
+func (s *stop) Cancel() {
+	log.Trace("tcp Cancel")
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+}
+
+func RunCtx(ctx context.Context, debugLevel, host, port, password string, banner ...string) error {
+	return RunWithOptionsAsync(host, port, password, WithBanner(banner...), WithLogLevel(debugLevel), WithCtx(ctx))
+}
+
+func WithCtx(ctx context.Context) serverOptsFunc {
+	return func(s *server) error {
+		if s.stop.cancel != nil {
+			s.stop.cancel()
+		}
+		s.stop = newStop(ctx)
+		s.stop.gui = true
+		return nil
+	}
+}
+
+// Ignore context cancellation error
+func Ignore(err error) error {
+	if err != nil && (errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		// ignore Listener closed during cancellation
+		// strings.Contains(err.Error(), "use of closed network connection") ||
+		errors.Is(err, net.ErrClosed)) {
+		log.Tracef("ignored: %v", err)
+		return nil
+	}
+	return err
+}

--- a/src/tcp/tcp.go
+++ b/src/tcp/tcp.go
@@ -325,7 +325,19 @@ func (s *server) clientCommunication(c *comm.Comm) (room string, err error) {
 	if err != nil {
 		return
 	}
-	passwordMatch := strings.TrimSpace(string(passwordBytes)) == s.password
+	clientPassword := strings.TrimSpace(string(passwordBytes))
+	passwordMatch := clientPassword == s.password
+	isDefaultPassword := clientPassword == models.DEFAULT_PASSPHRASE
+
+	// reject immediately if password is neither correct nor default
+	if !passwordMatch && !isDefaultPassword {
+		err = fmt.Errorf("bad password")
+		enc, _ := crypt.Encrypt([]byte(err.Error()), strongKeyForEncryption)
+		if err = c.Send(enc); err != nil {
+			return "", fmt.Errorf("send error: %w", err)
+		}
+		return
+	}
 
 	// send ok to tell client they are connected
 	banner := s.banner
@@ -358,7 +370,7 @@ func (s *server) clientCommunication(c *comm.Comm) (room string, err error) {
 	// create the room if it is new
 	if _, ok := s.rooms.rooms[room]; !ok {
 		// restricted access: client with default password cannot create rooms
-		if !passwordMatch {
+		if !passwordMatch && isDefaultPassword {
 			s.rooms.Unlock()
 			log.Debugf("restricted access: cannot create room %s with default password", room)
 			err = fmt.Errorf("bad password")

--- a/src/tcp/tcp.go
+++ b/src/tcp/tcp.go
@@ -329,14 +329,18 @@ func (s *server) clientCommunication(c *comm.Comm) (room string, err error) {
 	passwordMatch := clientPassword == s.password
 	isDefaultPassword := clientPassword == models.DEFAULT_PASSPHRASE
 
-	// reject immediately if password is neither correct nor default
-	if !passwordMatch && !isDefaultPassword {
-		err = fmt.Errorf("bad password")
-		enc, _ := crypt.Encrypt([]byte(err.Error()), strongKeyForEncryption)
-		if err = c.Send(enc); err != nil {
-			return "", fmt.Errorf("send error: %w", err)
+	if !passwordMatch {
+		// let sender create all rooms as first and anti-brute-force
+		time.Sleep(time.Second)
+		// reject if password is neither correct nor default
+		if !isDefaultPassword {
+			err = fmt.Errorf("bad password")
+			enc, _ := crypt.Encrypt([]byte(err.Error()), strongKeyForEncryption)
+			if err = c.Send(enc); err != nil {
+				return "", fmt.Errorf("send error: %w", err)
+			}
+			return
 		}
-		return
 	}
 
 	// send ok to tell client they are connected

--- a/src/tcp/tcp.go
+++ b/src/tcp/tcp.go
@@ -325,14 +325,7 @@ func (s *server) clientCommunication(c *comm.Comm) (room string, err error) {
 	if err != nil {
 		return
 	}
-	if strings.TrimSpace(string(passwordBytes)) != s.password {
-		err = fmt.Errorf("bad password")
-		enc, _ := crypt.Encrypt([]byte(err.Error()), strongKeyForEncryption)
-		if err = c.Send(enc); err != nil {
-			return "", fmt.Errorf("send error: %w", err)
-		}
-		return
-	}
+	passwordMatch := strings.TrimSpace(string(passwordBytes)) == s.password
 
 	// send ok to tell client they are connected
 	banner := s.banner
@@ -364,6 +357,17 @@ func (s *server) clientCommunication(c *comm.Comm) (room string, err error) {
 	s.rooms.Lock()
 	// create the room if it is new
 	if _, ok := s.rooms.rooms[room]; !ok {
+		// restricted access: client with default password cannot create rooms
+		if !passwordMatch {
+			s.rooms.Unlock()
+			log.Debugf("restricted access: cannot create room %s with default password", room)
+			err = fmt.Errorf("bad password")
+			enc, _ := crypt.Encrypt([]byte(err.Error()), strongKeyForEncryption)
+			if err = c.Send(enc); err != nil {
+				return "", fmt.Errorf("send error: %w", err)
+			}
+			return
+		}
 		s.rooms.rooms[room] = roomInfo{
 			first:  c,
 			opened: time.Now(),

--- a/src/tcp/tcp_test.go
+++ b/src/tcp/tcp_test.go
@@ -2,6 +2,7 @@ package tcp
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -17,14 +18,20 @@ func BenchmarkConnection(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		c, _, _, _ := ConnectToTCPServer("127.0.0.1:8283", "pass123", fmt.Sprintf("testroom%d", i), 1*time.Minute)
-		c.Close()
+		if c != nil {
+			c.Close()
+		}
 	}
 }
 
 func TestTCP(t *testing.T) {
 	log.SetLevel("error")
 	timeToRoomDeletion := 100 * time.Millisecond
-	go RunWithOptionsAsync("127.0.0.1", "8381", "pass123", WithBanner("8382"), WithLogLevel("debug"), WithRoomTTL(timeToRoomDeletion))
+	go RunWithOptionsAsync("127.0.0.1", "8381", "pass123",
+		WithBanner("8382"),
+		WithLogLevel("debug"),
+		WithRoomTTL(timeToRoomDeletion))
+
 	time.Sleep(timeToRoomDeletion)
 	err := PingServer("127.0.0.1:8381")
 	assert.Nil(t, err)
@@ -68,4 +75,234 @@ func TestTCP(t *testing.T) {
 
 	c1.Close()
 	time.Sleep(300 * time.Millisecond)
+}
+
+func TestTCPctx(t *testing.T) {
+	log.SetLevel("error")
+	// Set short room TTL for testing cleanup
+	timeToRoomDeletion := 100 * time.Millisecond
+
+	// Create cancelable context
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start server with custom options
+	go RunWithOptionsAsync("127.0.0.1", "8381", "pass123",
+		WithBanner("8382"),
+		WithLogLevel("debug"),
+		WithRoomTTL(timeToRoomDeletion),
+		WithCtx(ctx),
+	)
+
+	time.Sleep(timeToRoomDeletion)
+
+	// Test ping to running server
+	err := PingServer("127.0.0.1:8381")
+	assert.Nil(t, err)
+
+	// Test ping to non-existent server
+	err = PingServer("127.0.0.1:8333")
+	assert.NotNil(t, err)
+
+	time.Sleep(timeToRoomDeletion)
+
+	// Connect first client to room
+	c1, banner, _, err := ConnectToTCPServer("127.0.0.1:8381", "pass123", "testRoom", 1*time.Minute)
+	assert.Equal(t, banner, "8382")
+	assert.Nil(t, err)
+
+	// Connect second client to same room
+	c2, _, _, err := ConnectToTCPServer("127.0.0.1:8381", "pass123", "testRoom")
+	assert.Nil(t, err)
+
+	// Third client should fail - room is full
+	_, _, _, err = ConnectToTCPServer("127.0.0.1:8381", "pass123", "testRoom")
+	assert.NotNil(t, err)
+
+	// Connection with very short timeout should fail
+	_, _, _, err = ConnectToTCPServer("127.0.0.1:8381", "pass123", "testRoom", 1*time.Nanosecond)
+	assert.NotNil(t, err)
+
+	// Test data exchange between clients
+	// Send from c1 to c2
+	assert.Nil(t, c1.Send([]byte("hello, c2")))
+	var data []byte
+	for {
+		data, err = c2.Receive()
+		if bytes.Equal(data, []byte{1}) {
+			continue // Skip heartbeat
+		}
+		break
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("hello, c2"), data)
+
+	// Send from c2 to c1
+	assert.Nil(t, c2.Send([]byte("hello, c1")))
+	for {
+		data, err = c1.Receive()
+		if bytes.Equal(data, []byte{1}) {
+			continue // Skip heartbeat
+		}
+		break
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("hello, c1"), data)
+
+	// Close server
+	cancel()
+
+	// Test ping to non-existent server
+	err = PingServer("127.0.0.1:8331")
+	assert.NotNil(t, err)
+
+	time.Sleep(300 * time.Millisecond)
+}
+
+func TestWrongPassword(t *testing.T) {
+	log.SetLevel("error")
+	go Run("debug", "127.0.0.1", "8385", "pass123", "8386")
+	time.Sleep(100 * time.Millisecond)
+
+	// Attempt to connect with wrong password
+	_, _, _, err := ConnectToTCPServer("127.0.0.1:8385", "wrongpass", "testRoom")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "bad password")
+}
+
+func TestRoomIsolation(t *testing.T) {
+	log.SetLevel("error")
+	go Run("debug", "127.0.0.1", "8387", "pass123", "8388")
+	time.Sleep(100 * time.Millisecond)
+
+	// Room 1
+	c1, _, _, _ := ConnectToTCPServer("127.0.0.1:8387", "pass123", "room1")
+	c2, _, _, _ := ConnectToTCPServer("127.0.0.1:8387", "pass123", "room1")
+
+	// Room 2
+	c3, _, _, _ := ConnectToTCPServer("127.0.0.1:8387", "pass123", "room2")
+	c4, _, _, _ := ConnectToTCPServer("127.0.0.1:8387", "pass123", "room2")
+
+	// Send data in different rooms
+	c1.Send([]byte("to_room_1"))
+	c3.Send([]byte("to_room_2"))
+
+	// Verify reception
+	var data []byte
+
+	// c2 should receive message from room1
+	for {
+		data, _ = c2.Receive()
+		if bytes.Equal(data, []byte{1}) {
+			continue
+		}
+		break
+	}
+	assert.Equal(t, []byte("to_room_1"), data)
+
+	// c4 should receive message from room2
+	for {
+		data, _ = c4.Receive()
+		if bytes.Equal(data, []byte{1}) {
+			continue
+		}
+		break
+	}
+	assert.Equal(t, []byte("to_room_2"), data)
+
+	c1.Close()
+	c2.Close()
+	c3.Close()
+	c4.Close()
+}
+
+func TestRoomRecreationAfterTTL(t *testing.T) {
+	log.SetLevel("error")
+	shortTTL := 50 * time.Millisecond
+
+	go RunWithOptionsAsync("127.0.0.1", "8389", "pass123",
+		WithRoomTTL(shortTTL),
+		WithLogLevel("error"))
+	time.Sleep(100 * time.Millisecond)
+
+	roomName := "testRoomRecreate"
+
+	// 1. Create a room
+	c1, _, _, _ := ConnectToTCPServer("127.0.0.1:8389", "pass123", roomName)
+	assert.NotNil(t, c1)
+
+	// 2. Close first client, room becomes empty
+	c1.Close()
+
+	// 3. Wait for room cleanup (TTL + buffer)
+	time.Sleep(shortTTL + 50*time.Millisecond)
+
+	// 4. Try to connect to the same room again.
+	// If room wasn't deleted, we might get "room full" or weird behavior.
+	// If deleted — connection should succeed as the first client.
+	c3, _, _, err := ConnectToTCPServer("127.0.0.1:8389", "pass123", roomName)
+	assert.Nil(t, err)
+	assert.NotNil(t, c3)
+
+	if c3 != nil {
+		c3.Close()
+	}
+}
+
+func TestLargeDataTransfer(t *testing.T) {
+	log.SetLevel("error")
+	go Run("debug", "127.0.0.1", "8391", "pass123", "8392")
+	time.Sleep(100 * time.Millisecond)
+
+	c1, _, _, _ := ConnectToTCPServer("127.0.0.1:8391", "pass123", "bigRoom")
+	c2, _, _, _ := ConnectToTCPServer("127.0.0.1:8391", "pass123", "bigRoom")
+
+	// Generate data larger than standard buffer (e.g., 1 MB)
+	largeData := make([]byte, 1024*1024)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+
+	err := c1.Send(largeData)
+	assert.Nil(t, err)
+
+	var received []byte
+	// Receive data, as it might arrive in chunks (though chanFromConn buffers it)
+	// In this case pipe passes full Read packets, but for safety let's verify tail
+	for {
+		data, err := c2.Receive()
+		if bytes.Equal(data, []byte{1}) {
+			continue
+		}
+		assert.Nil(t, err)
+		received = data
+		break
+	}
+
+	assert.True(t, bytes.Equal(largeData, received), "Large data mismatch")
+
+	c1.Close()
+	c2.Close()
+}
+
+func TestServerReleasesPort(t *testing.T) {
+	log.SetLevel("trace")
+	host := "127.0.0.1"
+	port := "8394"
+
+	// 1. Start and automatically stop first server using timeout
+	// RunCtx blocks the execution, so we don't need 'go' or channels
+	ctx1, cancel1 := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel1()
+
+	err := RunCtx(ctx1, "trace", host, port, "pass123")
+	assert.Nil(t, err, "First server should stop gracefully")
+
+	// 2. Try to start second server on the same port immediately
+	// If port is not released, this will fail with "address already in use"
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel2()
+
+	err = RunCtx(ctx2, "trace", host, port, "pass123")
+	assert.Nil(t, err, "Second server should start (port was released)")
 }

--- a/src/tcp/tcp_test.go
+++ b/src/tcp/tcp_test.go
@@ -285,6 +285,70 @@ func TestLargeDataTransfer(t *testing.T) {
 	c2.Close()
 }
 
+func TestDefaultPasswordCanJoinExistingRoom(t *testing.T) {
+	log.SetLevel("error")
+	go Run("debug", "127.0.0.1", "8395", "secretpass", "8396")
+	time.Sleep(100 * time.Millisecond)
+
+	roomName := "restrictedRoom"
+
+	// Sender creates room with correct password
+	c1, _, _, err := ConnectToTCPServer("127.0.0.1:8395", "secretpass", roomName)
+	assert.Nil(t, err)
+	assert.NotNil(t, c1)
+
+	// Recipient joins existing room with default password (pass123)
+	c2, _, _, err := ConnectToTCPServer("127.0.0.1:8395", "pass123", roomName)
+	assert.Nil(t, err)
+	assert.NotNil(t, c2)
+
+	// Verify data exchange works
+	assert.Nil(t, c1.Send([]byte("hello from sender")))
+	var data []byte
+	for {
+		data, err = c2.Receive()
+		if bytes.Equal(data, []byte{1}) {
+			continue
+		}
+		break
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("hello from sender"), data)
+
+	c1.Close()
+	c2.Close()
+}
+
+func TestDefaultPasswordCannotCreateRoom(t *testing.T) {
+	log.SetLevel("error")
+	go Run("debug", "127.0.0.1", "8397", "secretpass", "8398")
+	time.Sleep(100 * time.Millisecond)
+
+	// Client with default password tries to create a new room (should fail)
+	_, _, _, err := ConnectToTCPServer("127.0.0.1:8397", "pass123", "newRoom")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "bad password")
+}
+
+func TestCorrectPasswordFullAccess(t *testing.T) {
+	log.SetLevel("error")
+	go Run("debug", "127.0.0.1", "8399", "secretpass", "8400")
+	time.Sleep(100 * time.Millisecond)
+
+	// Client with correct password can create room
+	c1, _, _, err := ConnectToTCPServer("127.0.0.1:8399", "secretpass", "fullAccessRoom")
+	assert.Nil(t, err)
+	assert.NotNil(t, c1)
+
+	// Another client with correct password can join
+	c2, _, _, err := ConnectToTCPServer("127.0.0.1:8399", "secretpass", "fullAccessRoom")
+	assert.Nil(t, err)
+	assert.NotNil(t, c2)
+
+	c1.Close()
+	c2.Close()
+}
+
 func TestServerReleasesPort(t *testing.T) {
 	log.SetLevel("trace")
 	host := "127.0.0.1"

--- a/src/tcp/tcp_test.go
+++ b/src/tcp/tcp_test.go
@@ -349,6 +349,24 @@ func TestCorrectPasswordFullAccess(t *testing.T) {
 	c2.Close()
 }
 
+func TestArbitraryWrongPasswordRejected(t *testing.T) {
+	log.SetLevel("error")
+	go Run("debug", "127.0.0.1", "8401", "secretpass", "8402")
+	time.Sleep(100 * time.Millisecond)
+
+	// Sender creates room with correct password
+	c1, _, _, err := ConnectToTCPServer("127.0.0.1:8401", "secretpass", "arbRoom")
+	assert.Nil(t, err)
+	assert.NotNil(t, c1)
+
+	// Client with arbitrary wrong password (not default) should be rejected immediately
+	_, _, _, err = ConnectToTCPServer("127.0.0.1:8401", "somegarbage", "arbRoom")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "bad password")
+
+	c1.Close()
+}
+
 func TestServerReleasesPort(t *testing.T) {
 	log.SetLevel("trace")
 	host := "127.0.0.1"

--- a/src/utils/ctx.go
+++ b/src/utils/ctx.go
@@ -1,0 +1,281 @@
+// ctx.go
+package utils
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/minio/highwayhash"
+	"github.com/schollz/progressbar/v3"
+)
+
+// ctxFile wraps os.File with context cancellation support.
+type ctxFile struct {
+	ctx context.Context
+	f   *os.File
+}
+
+// NewCtxFile creates a new context-aware file wrapper.
+func NewCtxFile(ctx context.Context, f *os.File) *ctxFile {
+	return &ctxFile{ctx: ctx, f: f}
+}
+
+// Read implements io.Reader interface with context cancellation.
+func (c *ctxFile) Read(p []byte) (n int, err error) {
+	select {
+	case <-c.ctx.Done():
+		return 0, c.ctx.Err()
+	default:
+		n, err = c.f.Read(p)
+		if c.ctx.Err() != nil {
+			return 0, c.ctx.Err()
+		}
+		return n, err
+	}
+}
+
+// ReadAt implements io.ReaderAt interface with context cancellation.
+func (c *ctxFile) ReadAt(p []byte, off int64) (n int, err error) {
+	select {
+	case <-c.ctx.Done():
+		return 0, c.ctx.Err()
+	default:
+		n, err = c.f.ReadAt(p, off)
+		if c.ctx.Err() != nil {
+			return 0, c.ctx.Err()
+		}
+		return n, err
+	}
+}
+
+// Seek implements io.Seeker interface with context cancellation.
+func (c *ctxFile) Seek(offset int64, whence int) (n int64, err error) {
+	select {
+	case <-c.ctx.Done():
+		return 0, c.ctx.Err()
+	default:
+		n, err = c.f.Seek(offset, whence)
+		if c.ctx.Err() != nil {
+			return 0, c.ctx.Err()
+		}
+		return n, err
+	}
+}
+
+// HashFileCtx returns the hash of a file with context cancellation support.
+func HashFileCtx(ctx context.Context, fname string, algorithm string, showProgress ...bool) ([]byte, error) {
+	// Quick context check before starting
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	fstats, err := os.Lstat(fname)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle symlinks - quick operation, no context needed
+	if fstats.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(fname)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(SHA256(target)), nil
+	}
+
+	f, err := os.Open(fname)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// Get file info for size (now file is opened, following symlinks if any)
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap the file with context support
+	cf := NewCtxFile(ctx, f)
+	sr := io.NewSectionReader(cf, 0, fi.Size())
+
+	// Parse showProgress parameter
+	doShowProgress := false
+	if len(showProgress) > 0 {
+		doShowProgress = showProgress[0]
+	}
+
+	// Create progress bar based on algorithm
+	var bar *progressbar.ProgressBar
+	if doShowProgress {
+		fnameShort := path.Base(fname)
+		if len(fnameShort) > 20 {
+			fnameShort = fnameShort[:20] + "..."
+		}
+
+		if algorithm == "imohash" {
+			// Spinner for imohash (indeterminate progress, max = -1)
+			bar = progressbar.NewOptions64(-1,
+				progressbar.OptionSetWriter(os.Stderr),
+				progressbar.OptionShowBytes(false),
+				progressbar.OptionSetDescription(fmt.Sprintf("Sampling %s", fnameShort)),
+				progressbar.OptionClearOnFinish(),
+				progressbar.OptionFullWidth(),
+				progressbar.OptionShowElapsedTimeOnFinish(),
+				progressbar.OptionSpinnerType(14),
+				progressbar.OptionSetSpinnerChangeInterval(100*time.Millisecond),
+			)
+		} else {
+			// Regular progress bar for other algorithms
+			bar = progressbar.NewOptions64(fi.Size(),
+				progressbar.OptionSetWriter(os.Stderr),
+				progressbar.OptionShowBytes(true),
+				progressbar.OptionSetDescription(fmt.Sprintf("Hashing %s", fnameShort)),
+				progressbar.OptionClearOnFinish(),
+				progressbar.OptionFullWidth(),
+			)
+		}
+	}
+
+	// Dispatch to appropriate hash function
+	switch algorithm {
+	case "imohash":
+		return IMOHashReader(sr, bar)
+	case "md5":
+		return MD5HashReader(sr, bar)
+	case "xxhash":
+		return XXHashReader(sr, bar)
+	case "highway":
+		return HighwayHashReader(sr, bar)
+	default:
+		return nil, fmt.Errorf("unsupported algorithm: %s", algorithm)
+	}
+}
+
+// IMOHashReader returns imohash for a SectionReader.
+// Uses spinner progress bar for indeterminate progress.
+func IMOHashReader(sr *io.SectionReader, bar *progressbar.ProgressBar) ([]byte, error) {
+	// Start spinner if provided
+	if bar != nil {
+		// Add(0) triggers initial render for spinner
+		bar.Add(0)
+	}
+
+	b, err := imopartial.SumSectionReader(sr)
+	if err != nil {
+		// If there's an error, finish the bar to clean up display
+		if bar != nil {
+			bar.Exit()
+		}
+		return nil, err
+	}
+
+	// Finish the progress bar
+	if bar != nil {
+		bar.Finish()
+	}
+
+	return b[:], nil
+}
+
+// IMOHashReaderFull returns full imohash (no sampling) for a SectionReader.
+func IMOHashReaderFull(sr *io.SectionReader, bar *progressbar.ProgressBar) ([]byte, error) {
+	// For full imohash (which reads entire file), use regular progress bar logic
+	if bar != nil {
+		bar.Add(0) // Start the spinner
+	}
+
+	b, err := imofull.SumSectionReader(sr)
+	if err != nil {
+		if bar != nil {
+			bar.Exit()
+		}
+		return nil, err
+	}
+
+	if bar != nil {
+		bar.Finish()
+	}
+
+	return b[:], nil
+}
+
+// MD5HashReader returns MD5 hash for a SectionReader.
+func MD5HashReader(sr *io.SectionReader, bar *progressbar.ProgressBar) ([]byte, error) {
+	// Reset to beginning
+	if _, err := sr.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	h := md5.New()
+	if bar != nil {
+		// Copy with progress tracking (like original code)
+		if _, err := io.Copy(io.MultiWriter(h, bar), sr); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := io.Copy(h, sr); err != nil {
+			return nil, err
+		}
+	}
+	return h.Sum(nil), nil
+}
+
+// XXHashReader returns xxhash for a SectionReader.
+func XXHashReader(sr *io.SectionReader, bar *progressbar.ProgressBar) ([]byte, error) {
+	if _, err := sr.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	h := xxhash.New()
+	if bar != nil {
+		if _, err := io.Copy(io.MultiWriter(h, bar), sr); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := io.Copy(h, sr); err != nil {
+			return nil, err
+		}
+	}
+	return h.Sum(nil), nil
+}
+
+// HighwayHashReader returns highwayhash for a SectionReader.
+func HighwayHashReader(sr *io.SectionReader, bar *progressbar.ProgressBar) ([]byte, error) {
+	if _, err := sr.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	key, err := hex.DecodeString("1553c5383fb0b86578c3310da665b4f6e0521acf22eb58a99532ffed02a6b115")
+	if err != nil {
+		return nil, err
+	}
+
+	h, err := highwayhash.New(key)
+	if err != nil {
+		return nil, fmt.Errorf("could not create highwayhash: %w", err)
+	}
+
+	if bar != nil {
+		if _, err := io.Copy(io.MultiWriter(h, bar), sr); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err := io.Copy(h, sr); err != nil {
+			return nil, err
+		}
+	}
+	return h.Sum(nil), nil
+}
+
+// Helper function to update existing HashFile to use HashFileCtx
+// func HashFile(fname string, algorithm string, showProgress ...bool) ([]byte, error) {
+// 	return HashFileCtx(context.Background(), fname, algorithm, showProgress...)
+// }

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -415,6 +415,9 @@ func ChunkRangesToChunks(chunkRanges []int64) (chunks []int64) {
 func GetLocalIPs() (ips []string, err error) {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
+		if ip := LocalIP(); ip != "" {
+			return []string{ip}, nil
+		}
 		return
 	}
 	ips = []string{}


### PR DESCRIPTION
>https://github.com/schollz/croc/issues/943
ctx, cancel := context.WithCancel(context.Background())
defer cancel()
...
c, err:=NewCtx(ctx, Options{...})
...
go func() {
 c.Send(...)
 donechan <- true
}()
go func() {
 <-cancelchan
 cancel()
}()
...
go func() {
 c.Receive()
 donechan <- true
}()
go func() {
 <-cancelchan
 cancel()
}()
...
