### PR TITLE
fix: add --socks5 and --connect flags to send subcommand

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -79,6 +79,8 @@ func Run() (err error) {
 				&cli.IntFlag{Name: "transfers", Value: 4, Usage: "number of ports to use for transfers"},
 				&cli.BoolFlag{Name: "qrcode", Aliases: []string{"qr"}, Usage: "show receive code as a qrcode"},
 				&cli.StringFlag{Name: "exclude", Value: "", Usage: "exclude files if they contain any of the comma separated strings"},
+				&cli.StringFlag{Name: "socks5", Value: "", Usage: "add a socks5 proxy", EnvVars: []string{"SOCKS5_PROXY"}},
+				&cli.StringFlag{Name: "connect", Value: "", Usage: "add a http proxy", EnvVars: []string{"HTTP_PROXY"}},
 			},
 			HelpName: "croc send",
 			Action:   send,


### PR DESCRIPTION
## Description

This PR fixes issue #1051 where users expected to use `--socks5` and `--connect` flags directly on the `send` subcommand, but these flags were only available as global flags.

## Changes

Added `--socks5` and `--connect` flags to the `send` subcommand's flag list, allowing both syntaxes to work:

- `croc --socks5 "127.0.0.1:9050" send file.txt` (existing global flag - still works)
- `croc send --socks5 "127.0.0.1:9050" file.txt` (new, more intuitive syntax)

## Why

Users naturally expect flags to work when placed after the subcommand. The current implementation only supported the global flag syntax, which required flags before `send`. While the README showed the correct syntax, this wasn't intuitive for users who are accustomed to specifying command-specific flags after the subcommand.

The environment variables `SOCKS5_PROXY` and `HTTP_PROXY` continue to work as fallbacks.

## Testing

The fix maintains backward compatibility:
- Global flags continue to work as before
- Environment variables continue to work as before  
- New subcommand-level flags now also work

## Related Issue

Fixes #1051