### PR TITLE
fix: Tell user minimum length of custom code

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ croc --classic
 
 #### Custom Code Phrase
 
-You can send with your own code phrase (must be more than 6 characters):
+You can send with your own code phrase (must be at least 6 characters):
 
 ```bash
 croc send --code [code-phrase] [file(s)-or-folder]

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -69,7 +69,7 @@ func Run() (err error) {
 			ArgsUsage:   "[filename(s) or folder]",
 			Flags: []cli.Flag{
 				&cli.BoolFlag{Name: "zip", Usage: "zip folder before sending"},
-				&cli.StringFlag{Name: "code", Aliases: []string{"c"}, Usage: "codephrase used to connect to relay"},
+				&cli.StringFlag{Name: "code", Aliases: []string{"c"}, Usage: "codephrase used to connect to relay (at least 6 characters)"},
 				&cli.StringFlag{Name: "hash", Value: "xxhash", Usage: "hash algorithm (xxhash, imohash, md5)"},
 				&cli.StringFlag{Name: "text", Aliases: []string{"t"}, Usage: "send some text"},
 				&cli.BoolFlag{Name: "no-local", Usage: "disable local relay when sending"},

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -213,7 +213,7 @@ func New(ops Options) (c *Client, err error) {
 	}
 
 	if len(c.Options.SharedSecret) < 6 {
-		err = fmt.Errorf("code is too short")
+		err = fmt.Errorf("code is too short (must be at least 6 characters)")
 		return
 	}
 	// Create a hash of part of the shared secret to use as the room name


### PR DESCRIPTION
When using a custom code, it must be at least 6 characters long but this is only specified in the README and not anywhere on the program itself, so I added it to the `code is too short` error and the `--help` output (along with fixing the README since it must be at least six, no more than six).