### PR TITLE
Add native Kotlin Android client to the Android section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,10 @@ go install github.com/schollz/croc/v10@latest
 
 ### On Android
 
-There is a 3rd-party F-Droid app [available to download](https://f-droid.org/packages/com.github.howeyc.crocgui/).
+There are two F-Droid apps available:
+
+- [crocgui](https://f-droid.org/packages/com.github.howeyc.crocgui/) — original port (Go, basic UI)
+- [croc-app](https://f-droid.org/en/packages/com.dking.crocapp/) — native Kotlin/Jetpack Compose client with a modern, mobile-first interface
 
 ## Usage
 


### PR DESCRIPTION
Updated the Android section to list both available F-Droid apps with short descriptions.

I built `croc-app`, a native Kotlin/Jetpack Compose Android client with a modern, mobile-first UI, and wanted to add it alongside the existing listing so users know it's available.

F-Droid: https://f-droid.org/en/packages/com.dking.crocapp/

Repo: https://github.com/Dking08/croc-app/