### PR TITLE
fix: honor --exclude and --git when --zip is used

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -408,7 +408,7 @@ func GetFilesInfo(fnames []string, zipfolder bool, ignoreGit bool, exclusions []
 			}
 			fpath = filepath.Dir(fpath)
 			dest := filepath.Base(fpath) + ".zip"
-			utils.ZipDirectory(dest, fpath)
+			utils.ZipDirectory(dest, fpath, ignoredPaths, exclusions)
 			utils.MarkFileForRemoval(dest)
 			stat, errStat = os.Lstat(dest)
 			if errStat != nil {

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -1,6 +1,7 @@
 package croc
 
 import (
+	"archive/zip"
 	"context"
 	"fmt"
 	"math/rand"
@@ -259,6 +260,85 @@ func TestCrocIgnoreGit(t *testing.T) {
 		if strings.Contains(file.Name, "LICENSE") {
 			t.Errorf("test failed, should ignore LICENSE")
 		}
+	}
+}
+
+// TestGetFilesInfoZipFolderHonoursFilters covers the integration between
+// GetFilesInfo and ZipDirectory when zipfolder=true. Regression test for
+// https://github.com/schollz/croc/issues/1087: --exclude and --git were
+// silently ignored in zip mode because the args weren't passed through.
+func TestGetFilesInfoZipFolderHonoursFilters(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "myproj")
+	for _, rel := range []string{
+		"main.go",
+		"node_modules/pkg.json",
+		".venv/file.py",
+		"build/output.bin",
+	} {
+		p := filepath.Join(src, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	// gitWalk calls MatchesPath(info.Name()) on basenames, which doesn't
+	// match patterns with trailing slashes. Use a plain pattern.
+	gitignore := filepath.Join(src, ".gitignore")
+	if err := os.WriteFile(gitignore, []byte("build\n"), 0o644); err != nil {
+		t.Fatalf("write .gitignore: %v", err)
+	}
+
+	// GetFilesInfo creates the zip in cwd, so chdir to a clean tmp location.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	filesInfo, _, _, err := GetFilesInfo([]string{"myproj"}, true /*zipfolder*/, true /*ignoreGit*/, []string{"node_modules", ".venv"})
+	if err != nil {
+		t.Fatalf("GetFilesInfo: %v", err)
+	}
+	if len(filesInfo) != 1 {
+		t.Fatalf("expected 1 FileInfo (the zip), got %d", len(filesInfo))
+	}
+	zipName := filesInfo[0].Name
+	defer os.Remove(zipName)
+
+	archive, err := zip.OpenReader(zipName)
+	if err != nil {
+		t.Fatalf("open zip %s: %v", zipName, err)
+	}
+	defer archive.Close()
+
+	got := make([]string, 0, len(archive.File))
+	for _, f := range archive.File {
+		got = append(got, f.Name)
+	}
+	for _, name := range got {
+		if strings.Contains(name, "node_modules") || strings.Contains(name, ".venv") {
+			t.Errorf("--exclude leak: %q is in zip\n  members: %v", name, got)
+		}
+		if strings.Contains(name, "build") {
+			t.Errorf("--git leak: %q is in zip\n  members: %v", name, got)
+		}
+	}
+	wantKept := "myproj/main.go"
+	found := false
+	for _, name := range got {
+		if name == wantKept {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected %q in zip; got %v", wantKept, got)
 	}
 }
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -499,7 +499,12 @@ func IsLocalIP(ipaddress string) bool {
 	return false
 }
 
-func ZipDirectory(destination string, source string) (err error) {
+// ZipDirectory writes the contents of source into a zip at destination.
+// Files whose absolute path is present in ignoredPaths are skipped (used by
+// the --git flag to honour .gitignore rules). Files whose zip path contains
+// any string in exclusions (case-insensitive) are also skipped, mirroring
+// the post-walk filter in cli.go for non-zip transfers.
+func ZipDirectory(destination string, source string, ignoredPaths map[string]bool, exclusions []string) (err error) {
 	if _, err = os.Stat(destination); err == nil {
 		log.Errorf("%s file already exists!\n", destination)
 		return fmt.Errorf("file already exists: %s", destination)
@@ -561,6 +566,17 @@ func ZipDirectory(destination string, source string) (err error) {
 			return nil
 		}
 
+		// Honour --git: skip paths flagged by .gitignore matching upstream.
+		if len(ignoredPaths) > 0 {
+			absPath, absErr := filepath.Abs(path)
+			if absErr == nil && ignoredPaths[absPath] {
+				if info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+		}
+
 		// Calculate relative path from source directory
 		relPath, err := filepath.Rel(source, path)
 		if err != nil {
@@ -571,6 +587,20 @@ func ZipDirectory(destination string, source string) (err error) {
 		// Create zip path with base name structure
 		zipPath := filepath.Join(baseName, relPath)
 		zipPath = filepath.ToSlash(zipPath)
+
+		// Honour --exclude: case-insensitive substring match against the zip
+		// path, mirroring the post-walk filter in cli.go.
+		if len(exclusions) > 0 {
+			zipPathLower := strings.ToLower(zipPath)
+			for _, exclusion := range exclusions {
+				if strings.Contains(zipPathLower, exclusion) {
+					if info.IsDir() {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+			}
+		}
 
 		if info.IsDir() {
 			// Add directory entry to zip with original modification time

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -533,7 +533,7 @@ func TestZipAndUnzipRoundTrip(t *testing.T) {
 
 	// Create zip
 	zipPath := filepath.Join(tmpDir, "test.zip")
-	err = ZipDirectory(zipPath, sourceDir)
+	err = ZipDirectory(zipPath, sourceDir, nil, nil)
 	if err != nil {
 		t.Fatalf("ZipDirectory failed: %v", err)
 	}
@@ -1036,5 +1036,120 @@ func TestHashFileCtxLargeFile(t *testing.T) {
 				assert.Equal(t, "3c32999529323ed66a67aeac5720c7bf1301dcc5dca87d8d46595e85ff990329", fmt.Sprintf("%x", hash))
 			}
 		})
+	}
+}
+
+// zipMembers returns the slash-separated names of every entry in the archive.
+func zipMembers(t *testing.T, zipPath string) []string {
+	t.Helper()
+	archive, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer archive.Close()
+	names := make([]string, 0, len(archive.File))
+	for _, f := range archive.File {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func writeFile(t *testing.T, dir, rel string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// TestZipDirectoryHonoursExclusions covers the --exclude flag in zip mode.
+// Regression test for https://github.com/schollz/croc/issues/1087.
+func TestZipDirectoryHonoursExclusions(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src")
+	for _, rel := range []string{
+		"main.go",
+		"node_modules/pkg.json",
+		".venv/file.py",
+	} {
+		writeFile(t, src, rel)
+	}
+
+	zipPath := filepath.Join(tmpDir, "src.zip")
+	if err := ZipDirectory(zipPath, src, nil, []string{"node_modules", ".venv"}); err != nil {
+		t.Fatalf("ZipDirectory: %v", err)
+	}
+
+	members := zipMembers(t, zipPath)
+	for _, name := range members {
+		if strings.Contains(name, "node_modules") || strings.Contains(name, ".venv") {
+			t.Errorf("excluded path leaked into zip: %s\n  members: %v", name, members)
+		}
+	}
+	wantKept := "src/main.go"
+	found := false
+	for _, name := range members {
+		if name == wantKept {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected %q in zip; got %v", wantKept, members)
+	}
+}
+
+// TestZipDirectoryHonoursIgnoredPaths covers the --git flag in zip mode.
+// Regression test for https://github.com/schollz/croc/issues/1087.
+func TestZipDirectoryHonoursIgnoredPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src")
+	for _, rel := range []string{
+		"main.go",
+		"build/output.bin",
+		"secrets/key.pem",
+	} {
+		writeFile(t, src, rel)
+	}
+
+	absSecrets, err := filepath.Abs(filepath.Join(src, "secrets"))
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	absSecretFile, err := filepath.Abs(filepath.Join(src, "secrets/key.pem"))
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	ignored := map[string]bool{
+		absSecrets:    true, // directory entry
+		absSecretFile: true, // file entry (gitWalk records both)
+	}
+
+	zipPath := filepath.Join(tmpDir, "src.zip")
+	if err := ZipDirectory(zipPath, src, ignored, nil); err != nil {
+		t.Fatalf("ZipDirectory: %v", err)
+	}
+
+	members := zipMembers(t, zipPath)
+	for _, name := range members {
+		if strings.Contains(name, "secrets") {
+			t.Errorf("ignored path leaked into zip: %s\n  members: %v", name, members)
+		}
+	}
+	wantKept := []string{"src/main.go", "src/build/output.bin"}
+	for _, want := range wantKept {
+		found := false
+		for _, name := range members {
+			if name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in zip; got %v", want, members)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1087.

In `--zip` mode, `croc send` builds the archive without consulting `--exclude` or the `--git` ignore set. The post-walk filter in `cli.go` runs after, but it can only match against the resulting `.zip` filename, never its contents, so excluded paths leak into the archive.

## Fix

Pass `ignoredPaths` and `exclusions` through to `utils.ZipDirectory` and skip matching entries during the walk, mirroring the non-zip filtering behaviour:

- `src/utils/utils.go::ZipDirectory` signature now takes `(destination, source string, ignoredPaths map[string]bool, exclusions []string)`. `--git` matches use `ignoredPaths[absPath]`; `--exclude` uses case-insensitive substring match against the zip-relative path, mirroring the existing post-filter in `cli.go`.
- `src/croc/croc.go:411` passes the existing `ignoredPaths` and `exclusions` through.

## Tests

Three new tests, all fail against `main`:

- `TestZipDirectoryHonoursExclusions` (utils): verifies `node_modules` and `.venv` are absent from a zip when given as `--exclude` patterns, and `main.go` is kept.
- `TestZipDirectoryHonoursIgnoredPaths` (utils): verifies a path in the `ignoredPaths` map is absent and the kept paths are present.
- `TestGetFilesInfoZipFolderHonoursFilters` (croc): end-to-end via `GetFilesInfo`. Populates a `.gitignore`, calls with both flags active, opens the resulting zip, and asserts the filtered contents.

`go test ./src/...`, `go build ./...`, and `go vet ./...` all clean locally.

## Note

The signature change to `utils.ZipDirectory` is technically an API break for any external consumer of `github.com/schollz/croc/v10/src/utils`. Only one in-tree caller exists. Happy to add a deprecated wrapper if you would rather not break it.
