### PR TITLE
feat: add CROC_PORT and CROC_PORTS env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,11 @@ USER nobody
 
 # Simple TCP health check with nc!
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD nc -z localhost 9009 || exit 1
+    CMD sh -c ' \
+    P="${CROC_PORTS:-${CROC_PORT:-9009}}"; \
+    for p in ${P//,/ }; do \
+        nc -z -w 3 localhost "$p" || exit 1; \
+    done'
 
 ENTRYPOINT ["/croc-entrypoint.sh"]
 CMD ["relay"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ USER nobody
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD sh -c ' \
     P="${CROC_PORTS:-${CROC_PORT:-9009}}"; \
-    for p in ${P//,/ }; do \
+    IFS=,; set -- $P; \
+    for p in "$@"; do \
         nc -z -w 3 localhost "$p" || exit 1; \
     done'
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,12 @@ To send files using your custom relay:
 croc --pass YOURPASSWORD --relay "myreal.example.com:9009" send [filename]
 ```
 
+To use custom ports, set `CROC_PORTS` (comma-separated) or `CROC_PORT` (base port):
+
+```bash
+docker run -d -p 9010-9011:9010-9011 -e CROC_PORTS='9010,9011' -e CROC_PASS='YOURPASSWORD' docker.io/schollz/croc
+```
+
 ## Acknowledgements
 
 `croc` has evolved through many iterations, and I am thankful for the contributions! Special thanks to:

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -93,8 +93,8 @@ func Run() (err error) {
 			Action:      relay,
 			Flags: []cli.Flag{
 				&cli.StringFlag{Name: "host", Usage: "host of the relay"},
-				&cli.StringFlag{Name: "ports", Value: "9009,9010,9011,9012,9013", Usage: "ports of the relay"},
-				&cli.IntFlag{Name: "port", Value: 9009, Usage: "base port for the relay"},
+				&cli.StringFlag{Name: "ports", Value: "9009,9010,9011,9012,9013", Usage: "ports of the relay", EnvVars: []string{"CROC_PORTS"}},
+				&cli.IntFlag{Name: "port", Value: 9009, Usage: "base port for the relay", EnvVars: []string{"CROC_PORT"}},
 				&cli.IntFlag{Name: "transfers", Value: 5, Usage: "number of ports to use for relay"},
 			},
 		},


### PR DESCRIPTION
- Add `CROC_PORTS` and `CROC_PORT` environment variables for the `relay` subcommand, matching the pattern used by `CROC_PASS`, `CROC_RELAY`, etc.
- Update Docker healthcheck to dynamically use these env vars instead of hardcoded port 9009
- Document the new env vars in README

Fixes #1096