### PR TITLE
Dockerfile: bump builder image to golang:1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache git gcc musl-dev
 


### PR DESCRIPTION
`go.mod` is at `1.25.0` since v10.4.0 but the Dockerfile still pulled `golang:1.24-alpine`, so the Deploy Docker action has been failing on every release tag with

    go: go.mod requires go >= 1.25.0 (running go 1.24.13)

Latest tag on Docker Hub is still v10.3.1. Bumping the builder to `1.25-alpine` should unblock it.

Closes #1103