### PR TITLE
Allow more than 16 transfers

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -1500,6 +1500,13 @@ func (c *Client) processMessagePake(m message.Message) (err error) {
 
 	// connects to the other ports of the server for transfer
 	var wg sync.WaitGroup
+
+       if need := len(c.Options.RelayPorts) + 1; len(c.conn) < need {
+               newConn := make([]*comm.Comm, need)
+               copy(newConn, c.conn)
+               c.conn = newConn
+       }
+
 	wg.Add(len(c.Options.RelayPorts))
 	for i := 0; i < len(c.Options.RelayPorts); i++ {
 		log.Debugf("port: [%s]", c.Options.RelayPorts[i])


### PR DESCRIPTION
Currently, the number of transfer slots allowed by croc is limited to 16.  If you specify --transfers 16 or higher on the command line, you will receive an index error when you try to receive files from the sender.

This small patch allows more than 16 simultaneous transfers, which can be useful for saturating extremely fast local links.  With --no-compress, --local and -transfers 16, I was able to exceed 16gbit/sec between two AWS instances with ephemeral SSD storage in the same VPC with this change.
