### PR TITLE
[codex] Extend read timeout for large resume messages

### DIFF
--- a/src/comm/comm.go
+++ b/src/comm/comm.go
@@ -23,6 +23,11 @@ var MAGIC_BYTES = []byte("croc")
 
 const maxReadMessageSize = 64 * 1024 * 1024
 
+// Large resume requests can contain hundreds of thousands of missing chunk
+// ranges. Keep the guard against malformed streams, but give legitimate large
+// control messages enough time to arrive through a relay.
+const messageBodyReadTimeout = 10 * time.Minute
+
 // Comm is some basic TCP communication
 type Comm struct {
 	connection net.Conn
@@ -183,8 +188,9 @@ func (c *Comm) Read() (buf []byte, numBytes int, bs []byte, err error) {
 	}
 	numBytes = int(numBytesUint32)
 
-	// shorten the reading deadline in case getting weird data
-	if err = c.connection.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+	// Shorten the reading deadline in case getting weird data, while still
+	// allowing large resume-control messages to cross slower relays.
+	if err = c.connection.SetReadDeadline(time.Now().Add(messageBodyReadTimeout)); err != nil {
 		log.Warnf("error setting read deadline: %v", err)
 	}
 	buf = make([]byte, numBytes)

--- a/src/comm/comm_test.go
+++ b/src/comm/comm_test.go
@@ -104,3 +104,24 @@ func TestReceiveRejectsOversizedMessage(t *testing.T) {
 	assert.Contains(t, err.Error(), "message too large")
 	assert.Nil(t, <-writeErr)
 }
+
+func TestReceiveAllowsLargeMessage(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	c := New(clientConn)
+	payload := bytes.Repeat([]byte("a"), 2*1024*1024)
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, err := New(serverConn).Write(payload)
+		writeErr <- err
+	}()
+
+	data, err := c.Receive()
+	assert.Nil(t, err)
+	assert.Equal(t, payload, data)
+	assert.Nil(t, <-writeErr)
+	assert.GreaterOrEqual(t, messageBodyReadTimeout, time.Minute)
+}


### PR DESCRIPTION
## Summary

- extend the framed message body read deadline from 10 seconds to 10 minutes
- keep the existing 64 MiB max message-size guard in place
- add a comm-layer test that receives a larger framed message

Fixes #1127.
Related: #946, #125.

## Root Cause

Resume requests for sparse or fragmented partial files can produce a large `recipientready` control message because the receiver sends the missing chunk ranges to the sender. On slower relayed connections, the sender may read the frame header and then hit the 10-second body read deadline before the full control message arrives. That aborts resume before data transfer starts.

## Validation

- `go test ./src/comm`
- manual validation with a 22.7 GB file resumed from an 84.7% partial: before this patch the sender timed out after the receiver sent `recipientready` with 113499 chunks; with the patch, missing chunks began writing into the existing partial file.

## Notes

This is intentionally narrow: it does not alter chunk selection, encryption, compression, or the maximum accepted frame size.
