### PR TITLE
fix: trim whitespace in relay --ports list

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -293,6 +293,19 @@ func shouldExitForUnixSendCode(goos string, codeFlagSet, classicInsecureMode boo
 	return goos != "windows" && codeFlagSet && !classicInsecureMode && envSecret == ""
 }
 
+// parseRelayPorts splits a comma-separated --ports value, trimming whitespace
+// around each entry and dropping empties. This keeps "9009, 9010," working the
+// same as "9009,9010" instead of producing invalid port strings like " 9010".
+func parseRelayPorts(portsFlag string) []string {
+	var ports []string
+	for _, p := range strings.Split(portsFlag, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			ports = append(ports, p)
+		}
+	}
+	return ports
+}
+
 func send(c *cli.Context) (err error) {
 	setDebugLevel(c)
 	comm.Socks5Proxy = c.String("socks5")
@@ -793,7 +806,7 @@ func relay(c *cli.Context) (err error) {
 	var ports []string
 
 	if c.IsSet("ports") {
-		ports = strings.Split(c.String("ports"), ",")
+		ports = parseRelayPorts(c.String("ports"))
 	} else {
 		portString := c.Int("port")
 		if portString == 0 {

--- a/src/cli/cli_test.go
+++ b/src/cli/cli_test.go
@@ -1,6 +1,52 @@
 package cli
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseRelayPorts(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{
+			name: "plain comma separated",
+			in:   "9009,9010,9011",
+			want: []string{"9009", "9010", "9011"},
+		},
+		{
+			name: "spaces after commas are trimmed",
+			in:   "9009, 9010, 9011",
+			want: []string{"9009", "9010", "9011"},
+		},
+		{
+			name: "surrounding and trailing empties are dropped",
+			in:   " 9009 ,, 9010 ,",
+			want: []string{"9009", "9010"},
+		},
+		{
+			name: "single port",
+			in:   "9009",
+			want: []string{"9009"},
+		},
+		{
+			name: "empty string yields no ports",
+			in:   "",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRelayPorts(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseRelayPorts(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestResolveSendSharedSecret(t *testing.T) {
 	t.Run("uses env secret", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`croc relay --ports` splits its value on `,` without trimming whitespace:

```go
ports = strings.Split(c.String("ports"), ",")
```

So a natural invocation like:

```
croc relay --ports "9009, 9010, 9011"
```

produces port strings `" 9010"` and `" 9011"` (with a leading space). Those aren't valid ports — the per-port relay goroutines fail when binding/resolving them (`tcp.Run` → `net.ResolveIPAddr`), and the whitespace is also advertised to clients through the relay banner (`tcpPorts := strings.Join(ports[1:], ",")`).

The comma-separated `--exclude` flag already trims entries and drops empties; `--ports` did not, so this is an inconsistency rather than an intentional difference.

## Fix

Add a small `parseRelayPorts` helper that splits on `,`, trims each entry, and drops empties — mirroring the existing `--exclude` handling. `"9009, 9010,"` is now parsed the same as `"9009,9010"`.

## Testing

- Added `TestParseRelayPorts` (table-driven, matching the existing style in this package).
- `go test ./src/cli/` passes; `go build ./...` and `go vet ./src/cli/` are clean.