### PR TITLE
Trim relay password consistently to fix 'password mismatch' regression

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -277,8 +277,9 @@ func determinePass(c *cli.Context) (pass string) {
 	pass = c.String("pass")
 	b, err := os.ReadFile(pass)
 	if err == nil {
-		pass = strings.TrimSpace(string(b))
+		pass = string(b)
 	}
+	pass = strings.TrimSpace(pass)
 	return
 }
 

--- a/src/cli/cli_test.go
+++ b/src/cli/cli_test.go
@@ -1,9 +1,28 @@
 package cli
 
 import (
+	"flag"
 	"reflect"
 	"testing"
+
+	"github.com/schollz/cli/v2"
 )
+
+// determinePass should trim a pass from --pass/CROC_PASS, not just from a file.
+func TestDeterminePassTrimsEnvValue(t *testing.T) {
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.String("pass", "", "")
+	if err := set.Set("pass", "pass123\n"); err != nil {
+		t.Fatalf("failed to set flag: %v", err)
+	}
+	ctx := cli.NewContext(nil, set, nil)
+
+	got := determinePass(ctx)
+	want := "pass123"
+	if got != want {
+		t.Errorf("determinePass(%q) = %q, want %q", "pass123\\n", got, want)
+	}
+}
 
 func TestParseRelayPorts(t *testing.T) {
 	tests := []struct {

--- a/src/tcp/tcp.go
+++ b/src/tcp/tcp.go
@@ -325,7 +325,7 @@ func (s *server) clientCommunication(c *comm.Comm) (room string, err error) {
 	if err != nil {
 		return
 	}
-	if strings.TrimSpace(string(passwordBytes)) != s.password {
+	if strings.TrimSpace(string(passwordBytes)) != strings.TrimSpace(s.password) {
 		err = fmt.Errorf("bad password")
 		enc, _ := crypt.Encrypt([]byte(err.Error()), strongKeyForEncryption)
 		if err = c.Send(enc); err != nil {

--- a/src/tcp/tcp_test.go
+++ b/src/tcp/tcp_test.go
@@ -170,6 +170,16 @@ func TestWrongPassword(t *testing.T) {
 	assert.Contains(t, err.Error(), "bad password")
 }
 
+// A relay password with trailing whitespace should still accept a trimmed client password.
+func TestPasswordWithTrailingWhitespace(t *testing.T) {
+	log.SetLevel("error")
+	go Run("debug", "127.0.0.1", "8395", "pass123 ", "8396")
+	time.Sleep(100 * time.Millisecond)
+
+	_, _, _, err := ConnectToTCPServer("127.0.0.1:8395", "pass123", "testRoom")
+	assert.Nil(t, err)
+}
+
 func TestRoomIsolation(t *testing.T) {
 	log.SetLevel("error")
 	go Run("debug", "127.0.0.1", "8387", "pass123", "8388")


### PR DESCRIPTION
Fixes #1149.

`determinePass` only trimmed the password when it was read from a file. A password passed via `--pass` or `CROC_PASS` with a trailing newline was left untrimmed, so the relay stored `pass\n` while the client sent (and the relay trimmed the received value to) `pass` — the two never matched and the handshake failed with "bad password" / "password mismatch". That's the regression between v10.4.5 and v10.4.6.

This trims the password regardless of where it came from, and trims both sides of the relay's comparison so a stored value with stray whitespace still works. Added a couple of regression tests.
