### PR TITLE
fix: Restore Windows-on-ARM64 build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           go version
           CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags '-extldflags "-static"' -o croc-windows-amd64.exe
+          CGO_ENABLED=0 GOOS=windows GOARCH=arm64 go build -ldflags '-extldflags "-static"' -o croc-windows-arm64.exe
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-extldflags "-static"' -o croc-linux-amd64
           CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags '-extldflags "-static"' -o croc-linux-386
           CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -ldflags '-extldflags "-static"' -o croc-linux-arm


### PR DESCRIPTION
Go 1.26.0 removes Windows-on-ARM32 support, but keeps ARM64. I still use croc on Windows-on-ARM64 regularly, so I want to make sure that the target build keeps getting tested, so it won't be forgotten.

Fixes #1086