### PR TITLE
fix: treat ".."-prefixed filenames as children in gitignore walk

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -746,7 +746,11 @@ func isChild(parentPath, childPath string) bool {
 	if err != nil {
 		return false
 	}
-	return !strings.HasPrefix(relPath, "..")
+	// Only "." or a component that is exactly ".." (optionally followed by more
+	// path segments) means childPath is not under parentPath. A bare HasPrefix
+	// on ".." wrongly rejects legitimate children whose name merely starts with
+	// ".." (e.g. "..cache"), matching the pathWithin helper in utils.
+	return relPath != ".." && !strings.HasPrefix(relPath, ".."+string(os.PathSeparator))
 }
 
 // This function retrieves the important file information

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -646,6 +646,25 @@ func TestGetFilesInfoZipFolderHonoursFilters(t *testing.T) {
 	}
 }
 
+// TestIsChild guards the gitignore walk helper. A directory or file whose
+// base name merely starts with ".." (e.g. "..cache") is still a legitimate
+// child of its parent and must be reported as such, otherwise it escapes the
+// inherited ignore rules in gitWalk and leaks into --git transfers.
+func TestIsChild(t *testing.T) {
+	sep := string(os.PathSeparator)
+	base := filepath.Join(sep+"a", "b")
+	// genuine descendants
+	assert.True(t, isChild(base, filepath.Join(base, "c")))
+	assert.True(t, isChild(base, filepath.Join(base, "c", "d")))
+	// a child whose name starts with ".." is still a child (regression)
+	assert.True(t, isChild(base, filepath.Join(base, "..cache")))
+	// the path itself is treated as a child
+	assert.True(t, isChild(base, base))
+	// siblings and ancestors are not children
+	assert.False(t, isChild(base, filepath.Join(sep+"a", "bc")))
+	assert.False(t, isChild(base, sep+"a"))
+}
+
 func TestGetFilesInfoZipFolderFromInsideSourceExcludesArchiveItself(t *testing.T) {
 	tmpDir := t.TempDir()
 	src := filepath.Join(tmpDir, "payload")


### PR DESCRIPTION
`isChild` used `strings.HasPrefix(relPath, "..")` to test whether a walked path lives under an ignored directory. That also matches legitimate children whose base name merely starts with ".." (for example `..cache`), where `filepath.Rel` returns `"..cache"` rather than `"../..."`. Those entries were reported as non-children, so `gitWalk` never propagated the parent directory's ignore status to them, and a file inside a `.gitignore`d folder could leak into a `--git` transfer.

Fix: check for the `".."` component exactly (or a leading `"../"` segment), mirroring the existing `pathWithin` helper in `utils`. Adds `TestIsChild` covering genuine descendants, the `..cache` regression case, self, sibling, and ancestor paths.

Verified locally: `go test ./src/croc/` (incl. the zip/`--git` regression tests), `gofmt -l`, and `go vet ./src/croc/` all clean. `TestIsChild` fails before the change and passes after.

Prepared with AI assistance (Claude) and reviewed/verified by me.
