### PR TITLE
Add exact file-path exclusion support via `--exclude-file`  #1163

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -79,6 +79,7 @@ func Run() (err error) {
 				&cli.IntFlag{Name: "transfers", Value: 4, Usage: "number of ports to use for transfers"},
 				&cli.BoolFlag{Name: "qrcode", Aliases: []string{"qr"}, Usage: "show receive code as a qrcode"},
 				&cli.StringFlag{Name: "exclude", Value: "", Usage: "exclude files if they contain any of the comma separated strings"},
+				&cli.StringFlag{Name: "exclude-file", Value: "", Usage: "exclude files matching any of the comma separated relative paths exactly"},
 				&cli.StringFlag{Name: "socks5", Value: "", Usage: "add a socks5 proxy", EnvVars: []string{"SOCKS5_PROXY"}},
 				&cli.StringFlag{Name: "connect", Value: "", Usage: "add a http proxy", EnvVars: []string{"HTTP_PROXY"}},
 			},
@@ -327,6 +328,13 @@ func send(c *cli.Context) (err error) {
 			excludeStrings = append(excludeStrings, v)
 		}
 	}
+	excludeFiles := []string{}
+	for _, v := range strings.Split(c.String("exclude-file"), ",") {
+		v = utils.NormalizeRelativePath(strings.TrimSpace(v))
+		if v != "" && v != "." {
+			excludeFiles = append(excludeFiles, v)
+		}
+	}
 
 	ports := make([]string, transfersParam+1)
 	for i := 0; i <= transfersParam; i++ {
@@ -359,6 +367,7 @@ func send(c *cli.Context) (err error) {
 		ShowQrCode:        c.Bool("qrcode"),
 		MulticastAddress:  c.String("multicast"),
 		Exclude:           excludeStrings,
+		ExcludeFile:       excludeFiles,
 		Quiet:             c.Bool("quiet"),
 		DisableClipboard:  c.Bool("disable-clipboard"),
 		ExtendedClipboard: c.Bool("extended-clipboard"),
@@ -475,7 +484,7 @@ Or you can go back to the classic croc behavior by enabling classic mode:
 		// generate code phrase
 		crocOptions.SharedSecret = utils.GetRandomName()
 	}
-	minimalFileInfos, emptyFoldersToTransfer, totalNumberFolders, err := croc.GetFilesInfo(fnames, crocOptions.ZipFolder, crocOptions.GitIgnore, crocOptions.Exclude)
+	minimalFileInfos, emptyFoldersToTransfer, totalNumberFolders, err := croc.GetFilesInfoWithExactExclusions(fnames, crocOptions.ZipFolder, crocOptions.GitIgnore, crocOptions.Exclude, crocOptions.ExcludeFile)
 	if err != nil {
 		return
 	}

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -99,6 +99,7 @@ type Options struct {
 	MulticastAddress  string
 	ShowQrCode        bool
 	Exclude           []string
+	ExcludeFile       []string
 	Quiet             bool
 	DisableClipboard  bool
 	ExtendedClipboard bool
@@ -752,6 +753,12 @@ func isChild(parentPath, childPath string) bool {
 // This function retrieves the important file information
 // for every file that will be transferred
 func GetFilesInfo(fnames []string, zipfolder bool, ignoreGit bool, exclusions []string) (filesInfo []FileInfo, emptyFolders []FileInfo, totalNumberFolders int, err error) {
+	return GetFilesInfoWithExactExclusions(fnames, zipfolder, ignoreGit, exclusions, nil)
+}
+
+// GetFilesInfoWithExactExclusions retrieves file information while applying
+// both the legacy substring exclusions and exact relative-path exclusions.
+func GetFilesInfoWithExactExclusions(fnames []string, zipfolder bool, ignoreGit bool, exclusions, exactExclusions []string) (filesInfo []FileInfo, emptyFolders []FileInfo, totalNumberFolders int, err error) {
 	// fnames: the relative/absolute paths of files/folders that will be transferred
 	totalNumberFolders = 0
 	var paths []string
@@ -827,7 +834,7 @@ func GetFilesInfo(fnames []string, zipfolder bool, ignoreGit bool, exclusions []
 			}
 			fpath = filepath.Dir(fpath)
 			dest := filepath.Base(fpath) + ".zip"
-			err = utils.ZipDirectory(dest, fpath, ignoredPaths, exclusions)
+			err = utils.ZipDirectoryWithExactExclusions(dest, fpath, ignoredPaths, exclusions, exactExclusions)
 			if err != nil {
 				return
 			}
@@ -873,6 +880,13 @@ func GetFilesInfo(fnames []string, zipfolder bool, ignoreGit bool, exclusions []
 					if strings.HasSuffix(absPathWithSeparator, string(os.PathSeparator)+string(os.PathSeparator)) {
 						absPathWithSeparator = strings.TrimSuffix(absPathWithSeparator, string(os.PathSeparator))
 					}
+					relPath, relErr := filepath.Rel(absPath, pathName)
+					if relErr == nil && exactPathExcluded(exactExclusions, relPath) {
+						if info.IsDir() {
+							return filepath.SkipDir
+						}
+						return nil
+					}
 					remoteFolder := strings.TrimPrefix(filepath.Dir(pathName), absPathWithSeparator)
 					if !info.IsDir() {
 						fInfo := FileInfo{
@@ -911,6 +925,9 @@ func GetFilesInfo(fnames []string, zipfolder bool, ignoreGit bool, exclusions []
 			}
 
 		} else {
+			if exactPathExcluded(exactExclusions, stat.Name()) {
+				continue
+			}
 			fInfo := FileInfo{
 				Name:         stat.Name(),
 				FolderRemote: "./",
@@ -929,6 +946,16 @@ func GetFilesInfo(fnames []string, zipfolder bool, ignoreGit bool, exclusions []
 		}
 	}
 	return
+}
+
+func exactPathExcluded(exclusions []string, candidate string) bool {
+	candidate = utils.NormalizeRelativePath(candidate)
+	for _, exclusion := range exclusions {
+		if candidate == utils.NormalizeRelativePath(exclusion) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) sendCollectFiles(filesInfo []FileInfo) (err error) {

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -768,6 +768,40 @@ func TestGetFilesInfoZipFolderHonoursFilters(t *testing.T) {
 	}
 }
 
+func TestGetFilesInfoExactFileExclusion(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	for _, rel := range []string{"a/image.jpg", "b/a/image.jpg", "photo.png"} {
+		file := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(file, []byte(rel), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	files, _, _, err := GetFilesInfoWithExactExclusions([]string{root}, false, false, nil, []string{"a/image.jpg"})
+	if err != nil {
+		t.Fatalf("GetFilesInfoWithExactExclusions: %v", err)
+	}
+	got := make(map[string]bool)
+	for _, file := range files {
+		rel, err := filepath.Rel(root, filepath.Join(file.FolderSource, file.Name))
+		if err != nil {
+			t.Fatalf("relative path: %v", err)
+		}
+		got[filepath.ToSlash(rel)] = true
+	}
+	if got["a/image.jpg"] {
+		t.Fatal("exactly excluded file was returned")
+	}
+	for _, want := range []string{"b/a/image.jpg", "photo.png"} {
+		if !got[want] {
+			t.Errorf("expected %q to be returned; got %v", want, got)
+		}
+	}
+}
+
 func TestGetFilesInfoZipFolderFromInsideSourceExcludesArchiveItself(t *testing.T) {
 	tmpDir := t.TempDir()
 	src := filepath.Join(tmpDir, "payload")

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -503,6 +503,13 @@ func IsLocalIP(ipaddress string) bool {
 // any string in exclusions (case-insensitive) are also skipped, mirroring
 // the post-walk filter in cli.go for non-zip transfers.
 func ZipDirectory(destination string, source string, ignoredPaths map[string]bool, exclusions []string) (err error) {
+	return ZipDirectoryWithExactExclusions(destination, source, ignoredPaths, exclusions, nil)
+}
+
+// ZipDirectoryWithExactExclusions is ZipDirectory with support for exact
+// paths relative to source. Legacy exclusions remain case-insensitive
+// substring matches.
+func ZipDirectoryWithExactExclusions(destination string, source string, ignoredPaths map[string]bool, exclusions, exactExclusions []string) (err error) {
 	if _, err = os.Stat(destination); err == nil {
 		log.Errorf("%s file already exists!\n", destination)
 		return fmt.Errorf("file already exists: %s", destination)
@@ -613,6 +620,7 @@ func ZipDirectory(destination string, source string, ignoredPaths map[string]boo
 		// Create zip path with base name structure
 		zipPath := filepath.Join(baseName, relPath)
 		zipPath = filepath.ToSlash(zipPath)
+		relPath = NormalizeRelativePath(relPath)
 
 		// Honour --exclude: case-insensitive substring match against the zip
 		// path, mirroring the post-walk filter in cli.go.
@@ -620,6 +628,16 @@ func ZipDirectory(destination string, source string, ignoredPaths map[string]boo
 			zipPathLower := strings.ToLower(zipPath)
 			for _, exclusion := range exclusions {
 				if strings.Contains(zipPathLower, exclusion) {
+					if info.IsDir() {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+			}
+		}
+		if len(exactExclusions) > 0 {
+			for _, exclusion := range exactExclusions {
+				if relPath == NormalizeRelativePath(exclusion) {
 					if info.IsDir() {
 						return filepath.SkipDir
 					}
@@ -691,6 +709,14 @@ func ZipDirectory(destination string, source string, ignoredPaths map[string]boo
 	}
 	fmt.Fprintf(os.Stderr, "\n")
 	return nil
+}
+
+// NormalizeRelativePath converts a path to a portable, clean relative-path
+// representation suitable for exact comparisons.
+func NormalizeRelativePath(p string) string {
+	p = filepath.ToSlash(filepath.Clean(p))
+	p = strings.TrimPrefix(p, "./")
+	return p
 }
 
 func pathWithin(parent string, child string) bool {


### PR DESCRIPTION
### Summary 
This change adds a new `--exclude-file` flag that excludes files by exact relative path, while
 preserving the existing `--exclude` substring/path-matching behavior.

 The goal is to let users exclude one specific file without accidentally excluding other files
 whose paths merely contain the same text.

### Problem (#1163)
The existing `--exclude` flag performs substring matching against relative file paths. This works well for broad exclusions (for example, excluding all files named image.jpg), but it cannot exclude only a single file when another file's path contains the same substring.

For example:
```
root_folder/
├── subfolder_01/
│   └── sub_subfolder_01/
│       └── image.jpg
└── subfolder_01/
    └── root_folder/
        └── subfolder_01/
            └── sub_subfolder_01/
                └── image.jpg
```

**Using:**
`croc send --exclude "root_folder/subfolder_01/sub_subfolder_01/image.jpg"`
causes both files to be excluded because the second file's relative path contains the first path as a substring.

### Solution

This PR introduces a new `--exclude-file` flag that performs exact normalized relative-path matching.

`--exclude` keeps its existing substring matching behavior for backward compatibility.
`--exclude-file` excludes only the file whose normalized relative path exactly matches the provided path.
The same matching logic is applied during both normal file discovery and archive (zip) creation.

### Validation

Verified manually using the directory structure from the reported issue.

### Results:

- No exclusions → 2 files transferred.
- `--exclude image.jpg` → both files excluded (existing behavior preserved).
- `--exclude-file subfolder_01/sub_subfolder_01/image.jpg` → only the targeted file is excluded, while the nested duplicate file is transferred.
