### PR TITLE
fix: prefer full-speed local relay for LAN transfers

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/denisbrodbeck/machineid"
@@ -46,8 +47,7 @@ var (
 	ipRequest        = []byte("ips?")
 	handshakeRequest = []byte("handshake")
 
-	alternateSenderRouteTimeout      = 10 * time.Second
-	alternateSenderRoutePollInterval = 50 * time.Millisecond
+	alternateSenderRouteTimeout = 10 * time.Second
 )
 
 const (
@@ -154,6 +154,9 @@ type Client struct {
 	reconnectRelayMu        sync.Mutex
 	reconnectVersion        int
 	peerReconnectVersion    int
+	senderRouteReady        chan struct{}
+	senderRouteReadyOnce    sync.Once
+	transferStarted         atomic.Bool
 	// localRelayPort is the control port of the ephemeral local relay started by
 	// setupLocalRelay(). It is captured before any goroutines that might
 	// overwrite c.Options.RelayPorts are launched.
@@ -290,6 +293,7 @@ func New(ops Options) (c *Client, err error) {
 	}
 
 	c.mutex = &sync.Mutex{}
+	c.senderRouteReady = make(chan struct{})
 	c.stop = newStop(context.Background())
 	return
 }
@@ -464,7 +468,17 @@ func (c *Client) currentRelayControlAddress() string {
 }
 
 func (c *Client) activeTransferStarted() bool {
-	return c.firstSend || c.Step3RecipientRequestFile || c.Step4FileTransferred
+	return c.transferStarted.Load()
+}
+
+func (c *Client) markTransferStarted() {
+	c.transferStarted.Store(true)
+}
+
+func (c *Client) markSenderRouteReady() {
+	c.senderRouteReadyOnce.Do(func() {
+		close(c.senderRouteReady)
+	})
 }
 
 func (c *Client) canRetryTransfer(err error, attempt int) bool {
@@ -1012,7 +1026,7 @@ func (c *Client) setupLocalRelay() {
 			}
 			err := c.stop.run(
 				debugString,
-				"127.0.0.1",
+				"",
 				portStr,
 				c.Options.RelayPassword,
 				localRelayBanner)
@@ -1094,6 +1108,7 @@ func (c *Client) transferOverLocalRelay(errchan chan<- error) {
 		c.Options.RelayPorts = []string{c.Options.RelayPorts[0]}
 	}
 	c.ExternalIP = ipaddr
+	c.markSenderRouteReady()
 	errchan <- c.transferWithReconnect(func(attempt int) error {
 		if attempt == 0 {
 			return nil
@@ -1200,30 +1215,23 @@ func isFatalSenderRouteError(err error) bool {
 
 func (c *Client) waitForAlternateSenderRoute(errchan <-chan error, originalErr error) error {
 	timeout := time.NewTimer(alternateSenderRouteTimeout)
-	ticker := time.NewTicker(alternateSenderRoutePollInterval)
 	defer timeout.Stop()
-	defer ticker.Stop()
 
-	for {
-		if c.activeTransferStarted() {
-			select {
-			case err := <-errchan:
-				return err
-			case <-c.stop.ctx.Done():
-				return c.stop.ctx.Err()
-			}
-		}
-
+	select {
+	case <-c.senderRouteReady:
 		select {
 		case err := <-errchan:
 			return err
-		case <-ticker.C:
-		case <-timeout.C:
-			log.Debug("timed out waiting for alternate sender route")
-			return originalErr
 		case <-c.stop.ctx.Done():
 			return c.stop.ctx.Err()
 		}
+	case err := <-errchan:
+		return err
+	case <-timeout.C:
+		log.Debug("timed out waiting for alternate sender route")
+		return originalErr
+	case <-c.stop.ctx.Done():
+		return c.stop.ctx.Err()
 	}
 }
 
@@ -1395,6 +1403,7 @@ On the other computer run:
 			}
 			c.ExternalIP = ipaddr
 			log.Debug("exchanged header message")
+			c.markSenderRouteReady()
 			errchan <- c.transferWithReconnect(func(attempt int) error {
 				if attempt == 0 {
 					return nil
@@ -2021,6 +2030,7 @@ func (c *Client) processMessageFileInfo(m message.Message) (done bool, err error
 		c.SuccessfulTransfer = true
 		c.Step3RecipientRequestFile = true
 		c.Step4FileTransferred = true
+		c.markTransferStarted()
 		errStopTransfer := message.Send(c.conn[0], c.Key, message.Message{
 			Type: message.TypeFinished,
 		})
@@ -2235,6 +2245,7 @@ func (c *Client) processMessage(payload []byte, attempt *transferAttemptState) (
 		}
 		c.mutex.Unlock()
 		c.Step3RecipientRequestFile = true
+		c.markTransferStarted()
 
 		if c.Options.Ask {
 			fmt.Fprintf(os.Stderr, "Send to machine '%s'? (Y/n) ", remoteFile.MachineID)
@@ -2430,6 +2441,7 @@ func (c *Client) recipientGetFileReady(finished bool) (err error) {
 		return
 	}
 	c.Step3RecipientRequestFile = true
+	c.markTransferStarted()
 	return
 }
 
@@ -2671,6 +2683,7 @@ func (c *Client) updateState(attempt *transferAttemptState) (err error) {
 			}
 		}
 		c.Step4FileTransferred = true
+		c.markTransferStarted()
 		// setup the progressbar
 		c.setBar()
 		c.TotalSent = 0

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -901,7 +901,7 @@ func TestCrocLocal(t *testing.T) {
 	wg.Wait()
 }
 
-func TestSenderWaitsForLocalRelayAfterExternalRelayCloses(t *testing.T) {
+func TestSenderAndReceiverPreferLocalRelayOverExternalRelay(t *testing.T) {
 	log.SetLevel("warn")
 	localIPs, err := utils.GetLocalIPs()
 	if err != nil || len(localIPs) == 0 {
@@ -965,10 +965,6 @@ func TestSenderWaitsForLocalRelayAfterExternalRelayCloses(t *testing.T) {
 		errc <- sender.Send(filesInfo, emptyFolders, totalNumberFolders)
 	}()
 	go func() {
-		if err := waitHashed(sender); err != nil {
-			errc <- err
-			return
-		}
 		errc <- receiver.Receive()
 	}()
 
@@ -977,6 +973,13 @@ func TestSenderWaitsForLocalRelayAfterExternalRelayCloses(t *testing.T) {
 			t.Fatalf("transfer failed: %v", err)
 		}
 	}
+
+	localControlAddress := net.JoinHostPort("127.0.0.1", sender.localRelayPort)
+	assert.Equal(t, localControlAddress, sender.currentRelayControlAddress())
+	_, receiverPort, err := net.SplitHostPort(receiver.currentRelayControlAddress())
+	assert.NoError(t, err)
+	assert.Equal(t, sender.localRelayPort, receiverPort)
+	assert.NotEqual(t, externalPorts[0], receiverPort)
 }
 
 func TestSenderLocalProbeDoesNotCorruptExternalRoute(t *testing.T) {
@@ -1496,25 +1499,23 @@ func TestReconnectFallsBackToRememberedRelay(t *testing.T) {
 	assert.Equal(t, relayAddress, receiver.Options.RelayAddress)
 }
 
-func TestSenderWaitsPastAlternateRouteTimeoutAfterTransferStarts(t *testing.T) {
+func TestSenderWaitsPastAlternateRouteTimeoutAfterRouteIsReady(t *testing.T) {
 	oldTimeout := alternateSenderRouteTimeout
-	oldPollInterval := alternateSenderRoutePollInterval
 	defer func() {
 		alternateSenderRouteTimeout = oldTimeout
-		alternateSenderRoutePollInterval = oldPollInterval
 	}()
 	alternateSenderRouteTimeout = 30 * time.Millisecond
-	alternateSenderRoutePollInterval = 5 * time.Millisecond
 
 	c := &Client{
-		stop: newStop(context.Background()),
+		stop:             newStop(context.Background()),
+		senderRouteReady: make(chan struct{}),
 	}
 	errchan := make(chan error, 1)
 	originalErr := fmt.Errorf("losing route EOF")
 
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		c.firstSend = true
+		c.markSenderRouteReady()
 		time.Sleep(60 * time.Millisecond)
 		errchan <- nil
 	}()

--- a/src/tcp/tcp_test.go
+++ b/src/tcp/tcp_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"testing"
 	"time"
 
@@ -315,4 +316,75 @@ func TestServerReleasesPort(t *testing.T) {
 
 	err = RunCtx(ctx2, "trace", host, port, "pass123")
 	assert.Nil(t, err, "Second server should start (port was released)")
+}
+
+func TestDualStackRelayBridgesIPv4AndIPv6(t *testing.T) {
+	probe, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skipf("IPv6 loopback is unavailable: %v", err)
+	}
+	_, port, err := net.SplitHostPort(probe.Addr().String())
+	if err != nil {
+		probe.Close()
+		t.Fatalf("split probe address: %v", err)
+	}
+	probe.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- RunCtx(ctx, "error", "", port, "pass123")
+	}()
+	defer func() {
+		cancel()
+		select {
+		case <-serverErr:
+		case <-time.After(time.Second):
+		}
+	}()
+
+	ipv4Address := net.JoinHostPort("127.0.0.1", port)
+	ipv6Address := net.JoinHostPort("::1", port)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if PingServer(ipv4Address) == nil && PingServer(ipv6Address) == nil {
+			break
+		}
+		select {
+		case err := <-serverErr:
+			t.Fatalf("dual-stack relay stopped during startup: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("relay did not become reachable over both IPv4 and IPv6")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	ipv4Client, _, _, err := ConnectToTCPServer(ipv4Address, "pass123", "dual-stack-room")
+	if err != nil {
+		t.Fatalf("connect IPv4 client: %v", err)
+	}
+	defer ipv4Client.Close()
+	ipv6Client, _, _, err := ConnectToTCPServer(ipv6Address, "pass123", "dual-stack-room")
+	if err != nil {
+		t.Fatalf("connect IPv6 client: %v", err)
+	}
+	defer ipv6Client.Close()
+
+	want := []byte("local relay payload")
+	if err := ipv4Client.Send(want); err != nil {
+		t.Fatalf("send IPv4 payload: %v", err)
+	}
+	var got []byte
+	for {
+		got, err = ipv6Client.Receive()
+		if err != nil {
+			t.Fatalf("receive IPv6 payload: %v", err)
+		}
+		if !bytes.Equal(got, []byte{1}) {
+			break
+		}
+	}
+	assert.Equal(t, want, got)
 }

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -418,11 +418,16 @@ func GetLocalIPs() (ips []string, err error) {
 		}
 		return
 	}
-	ips = []string{}
+	return localIPsFromAddrs(addrs), nil
+}
+
+func localIPsFromAddrs(addrs []net.Addr) (ips []string) {
 	for _, address := range addrs {
-		// check the address type and if it is not a loopback the display it
+		// Return every routable interface address. IPv6 link-local addresses are
+		// discovered through multicast instead because dialing them also requires
+		// the receiver's local interface zone.
 		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			if ipnet.IP.To4() != nil {
+			if ipnet.IP.To4() != nil || (ipnet.IP.To16() != nil && !ipnet.IP.IsLinkLocalUnicast()) {
 				ips = append(ips, ipnet.IP.String())
 			}
 		}

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -271,6 +272,19 @@ func TestLocalIP(t *testing.T) {
 	ip := LocalIP()
 	fmt.Println(ip)
 	assert.True(t, strings.Contains(ip, ".") || strings.Contains(ip, ":"))
+}
+
+func TestLocalIPsFromAddrsIncludesRoutableIPv4AndIPv6(t *testing.T) {
+	addrs := []net.Addr{
+		&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)},
+		&net.IPNet{IP: net.ParseIP("192.168.1.20"), Mask: net.CIDRMask(24, 32)},
+		&net.IPNet{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)},
+		&net.IPNet{IP: net.ParseIP("fe80::20"), Mask: net.CIDRMask(64, 128)},
+		&net.IPNet{IP: net.ParseIP("fd00::20"), Mask: net.CIDRMask(64, 128)},
+		&net.IPNet{IP: net.ParseIP("2001:db8::20"), Mask: net.CIDRMask(64, 128)},
+	}
+
+	assert.Equal(t, []string{"192.168.1.20", "fd00::20", "2001:db8::20"}, localIPsFromAddrs(addrs))
 }
 
 func TestGetRandomName(t *testing.T) {


### PR DESCRIPTION
## Summary

- replace racy sender route polling with synchronized route-ready and transfer state
- bind the ephemeral local relay as dual-stack and advertise routable IPv6 addresses
- verify that same-network transfers select the local relay instead of the external relay
- add IPv4-to-IPv6 relay coverage and local address filtering tests

This keeps transfer payloads on the LAN when the peers can reach each other directly, avoiding carrier upload limits while preserving the external relay as a fallback.

## Testing

- `go test ./...`
- focused LAN route-selection and timeout tests repeated three times