### PR TITLE
docs: document --exclude-file flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,16 @@ croc --yes --overwrite <code>
 
 #### Excluding Folders
 
-To exclude folders from being sent, use the `--exclude` flag with comma-delimited exclusions:
+To exclude folders from being sent, use the `--exclude` flag with comma-delimited exclusions. This does a case-insensitive **substring** match against each file's relative path, so any path containing one of the given strings anywhere is excluded:
 
 ```bash
 croc send --exclude "node_modules,.venv" [folder]
+```
+
+If you need to exclude one specific file rather than every path containing a substring (for example, two files share a name at different depths and only one should be excluded), use `--exclude-file` instead. It takes comma-delimited relative paths and matches them **exactly**:
+
+```bash
+croc send --exclude-file "subfolder/image.jpg" [folder]
 ```
 
 #### Use Pipes - stdin and stdout


### PR DESCRIPTION
## Context

Related to #1163.

\`--exclude-file\` already exists in the CLI (\`src/cli/cli.go\`) and does exact relative-path matching via \`exactPathExcluded\`, as opposed to \`--exclude\`'s substring matching. It just isn't mentioned anywhere in the README, so users hit the substring-collision problem described in #1163 without knowing there's already a flag that solves it.

## Change

Adds a short explanation to the "Excluding Folders" section distinguishing the two flags, with an example for each.

I left a comment on #1163 pointing to \`--exclude-file\` as the existing fix — this PR closes the documentation gap that made the issue possible in the first place.