### PR TITLE
docs: add FlCroc to third-party GUI list

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ There are two F-Droid apps available:
 - [crocgui](https://f-droid.org/packages/com.github.howeyc.crocgui/) — original port (Go, basic UI)
 - [croc-app](https://f-droid.org/en/packages/com.dking.crocapp/) — native Kotlin/Jetpack Compose client with a modern, mobile-first interface
 
+[FlCroc](https://github.com/576576/FlCroc) is a cross-platform Flutter GUI (Android, Windows, Linux) that wraps the `croc` binary as its transfer core.
+
 ## Usage
 
 To send a file, simply do:


### PR DESCRIPTION
Fixes #1123.

Adds [FlCroc](https://github.com/576576/FlCroc) to the README's Android GUI list, alongside the existing crocgui and croc-app entries. FlCroc is cross-platform (Android, Windows, Linux) and uses the croc binary as its transfer core, as noted in the issue.