### PR TITLE
fix: reject non-local zip paths on Windows

### DIFF
--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -844,7 +844,7 @@ func UnzipDirectory(destination string, source string) error {
 }
 
 func resolveUnzipPath(destination string, entryName string) (string, error) {
-	if filepath.IsAbs(entryName) || filepath.VolumeName(entryName) != "" {
+	if !filepath.IsLocal(entryName) {
 		return "", fmt.Errorf("path escapes destination")
 	}
 

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -504,14 +504,55 @@ func TestUnzipDirectoryRejectsPathTraversal(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr), "pre-validation should prevent partial extraction")
 }
 
-func TestResolveUnzipPathRejectsAbsolutePathEntry(t *testing.T) {
+func TestResolveUnzipPathRejectsNonLocalEntries(t *testing.T) {
 	destination := t.TempDir()
-	absoluteEntry := filepath.Join(string(os.PathSeparator), "tmp", "croc-absolute-escape.txt")
+	tests := []struct {
+		name  string
+		entry string
+	}{
+		{
+			name:  "absolute path",
+			entry: filepath.Join(string(os.PathSeparator), "tmp", "croc-absolute-escape.txt"),
+		},
+		{
+			name:  "parent directory",
+			entry: "..",
+		},
+		{
+			name:  "parent traversal",
+			entry: filepath.Join("..", "croc-relative-escape.txt"),
+		},
+		{
+			name:  "nested parent traversal",
+			entry: filepath.Join("safe", "..", "..", "croc-relative-escape.txt"),
+		},
+		{
+			name:  "empty path",
+			entry: "",
+		},
+	}
 
-	_, err := resolveUnzipPath(destination, absoluteEntry)
-	assert.NotNil(t, err)
-	if err != nil {
-		assert.Contains(t, err.Error(), "path escapes destination")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := resolveUnzipPath(destination, tt.entry)
+			assert.ErrorContains(t, err, "path escapes destination")
+		})
+	}
+}
+
+func TestResolveUnzipPathAllowsLocalEntries(t *testing.T) {
+	destination := t.TempDir()
+
+	for _, entry := range []string{
+		"file.txt",
+		filepath.Join("directory", "file.txt"),
+		"directory..name",
+	} {
+		t.Run(entry, func(t *testing.T) {
+			resolved, err := resolveUnzipPath(destination, entry)
+			assert.NoError(t, err)
+			assert.Equal(t, filepath.Join(destination, entry), resolved)
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- reject every non-local ZIP entry before extraction
- fix root-relative path handling on Windows, where paths such as `\tmp\file` are rooted but are not reported by `filepath.IsAbs`
- expand regression coverage for absolute, empty, and parent-traversing paths while preserving valid local paths

## Why

`resolveUnzipPath` previously combined `filepath.IsAbs` and `filepath.VolumeName`. On Windows, a root-relative path can pass both checks. The existing absolute-entry regression test therefore fails on Windows, leaving platform-specific path validation inconsistent at the ZIP extraction boundary.

`filepath.IsLocal` is the standard-library lexical containment check: when it returns true, joining the entry to a base is guaranteed to remain within that base. It also rejects empty paths and Windows reserved names.

## Testing

- `go test ./src/utils -run 'TestResolveUnzipPath|TestUnzipDirectoryRejectsPathTraversal' -count=1`
- `go test ./src/utils -count=1`
- `go test ./... -skip '^TestCrocSymlink$' -count=1`
- `go vet ./...`

The symlink test was skipped in the full Windows run because the local account does not have the Windows symlink-creation privilege; all other packages and tests passed.