### PR TITLE
feat: add --rename flag to receive existing files under a new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ To automatically overwrite files without prompting, use the `--overwrite` flag:
 croc --yes --overwrite <code>
 ```
 
+#### Keep Both Files Without Prompt
+
+To keep an existing file and receive the incoming one under a new name (e.g. `video (1).mkv`), use the `--rename` flag:
+
+```bash
+croc --yes --rename <code>
+```
+
 #### Excluding Folders
 
 To exclude folders from being sent, use the `--exclude` flag with comma-delimited exclusions:

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -123,6 +123,7 @@ func Run() (err error) {
 		&cli.BoolFlag{Name: "local", Usage: "force to use only local connections"},
 		&cli.BoolFlag{Name: "ignore-stdin", Usage: "ignore piped stdin"},
 		&cli.BoolFlag{Name: "overwrite", Usage: "do not prompt to overwrite or resume"},
+		&cli.BoolFlag{Name: "rename", Usage: "receive files that already exist under a new name instead of prompting"},
 		&cli.BoolFlag{Name: "testing", Usage: "flag for testing purposes"},
 		&cli.BoolFlag{Name: "quiet", Usage: "disable all output"},
 		&cli.BoolFlag{Name: "disable-clipboard", Usage: "disable copy to clipboard"},
@@ -363,6 +364,7 @@ func send(c *cli.Context) (err error) {
 		SendingText:       c.String("text") != "",
 		NoCompress:        c.Bool("no-compress"),
 		Overwrite:         c.Bool("overwrite"),
+		Rename:            c.Bool("rename"),
 		Curve:             c.String("curve"),
 		HashAlgorithm:     c.String("hash"),
 		ThrottleUpload:    c.String("throttleUpload"),
@@ -404,6 +406,9 @@ func send(c *cli.Context) (err error) {
 		}
 		if !c.IsSet("overwrite") {
 			crocOptions.Overwrite = rememberedOptions.Overwrite
+		}
+		if !c.IsSet("rename") {
+			crocOptions.Rename = rememberedOptions.Rename
 		}
 		if !c.IsSet("curve") && rememberedOptions.Curve != "" {
 			crocOptions.Curve = rememberedOptions.Curve
@@ -628,6 +633,7 @@ func receive(c *cli.Context) (err error) {
 		OnlyLocal:         c.Bool("local"),
 		IP:                c.String("ip"),
 		Overwrite:         c.Bool("overwrite"),
+		Rename:            c.Bool("rename"),
 		Curve:             c.String("curve"),
 		TestFlag:          c.Bool("testing"),
 		MulticastAddress:  c.String("multicast"),
@@ -681,6 +687,9 @@ func receive(c *cli.Context) (err error) {
 		}
 		if !c.IsSet("overwrite") {
 			crocOptions.Overwrite = rememberedOptions.Overwrite
+		}
+		if !c.IsSet("rename") {
+			crocOptions.Rename = rememberedOptions.Rename
 		}
 		if !c.IsSet("curve") && rememberedOptions.Curve != "" {
 			crocOptions.Curve = rememberedOptions.Curve

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -90,6 +90,7 @@ type Options struct {
 	NoCompress        bool
 	IP                string
 	Overwrite         bool
+	Rename            bool
 	Curve             string
 	HashAlgorithm     string
 	ThrottleUpload    string
@@ -2613,7 +2614,13 @@ func (c *Client) updateIfRecipientHasFileInfo() (err error) {
 		if !bytes.Equal(fileHash, fileInfo.Hash) {
 			log.Debugf("hashed %s to %x using %s", fileInfo.Name, fileHash, c.Options.HashAlgorithm)
 			log.Debugf("hashes are not equal %x != %x", fileHash, fileInfo.Hash)
-			if errHash == nil && !c.Options.Overwrite && errRecipientFile == nil && !strings.HasPrefix(fileInfo.Name, "croc-stdin-") && !c.Options.SendingText {
+			if errHash == nil && errRecipientFile == nil && !strings.HasPrefix(fileInfo.Name, "croc-stdin-") && !c.Options.SendingText && c.Options.Rename {
+				newName := utils.UnusedFilename(fileInfo.FolderRemote, fileInfo.Name)
+				fmt.Fprintf(os.Stderr, "Receiving '%s' as '%s'\n", fileInfo.Name, newName)
+				c.FilesToTransfer[i].Name = newName
+				fileInfo.Name = newName
+			}
+			if errHash == nil && !c.Options.Overwrite && !c.Options.Rename && errRecipientFile == nil && !strings.HasPrefix(fileInfo.Name, "croc-stdin-") && !c.Options.SendingText {
 
 				missingChunks := utils.ChunkRangesToChunks(utils.MissingChunks(
 					path.Join(fileInfo.FolderRemote, fileInfo.Name),

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -506,6 +506,105 @@ func TestCrocNonASCIIFileName(t *testing.T) {
 	}
 }
 
+func TestCrocRenameExistingFile(t *testing.T) {
+	testDir := t.TempDir()
+	sourceDir := filepath.Join(testDir, "source")
+	receiveDir := filepath.Join(testDir, "receive")
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("create source directory: %v", err)
+	}
+	if err := os.MkdirAll(receiveDir, 0o755); err != nil {
+		t.Fatalf("create receive directory: %v", err)
+	}
+
+	const fileName = "video.mkv"
+	want := bytes.Repeat([]byte("new"), 1000)
+	existing := []byte("existing content")
+	sourcePath := filepath.Join(sourceDir, fileName)
+	if err := os.WriteFile(sourcePath, want, 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(receiveDir, fileName), existing, 0o644); err != nil {
+		t.Fatalf("write existing file: %v", err)
+	}
+
+	filesInfo, emptyFolders, totalNumberFolders, err := GetFilesInfo([]string{sourcePath}, false, false, nil)
+	if err != nil {
+		t.Fatalf("get source file info: %v", err)
+	}
+
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	if err := os.Chdir(receiveDir); err != nil {
+		t.Fatalf("change to receive directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalCwd); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
+
+	secret := fmt.Sprintf("rename-existing-%d", time.Now().UnixNano())
+	sender, err := New(Options{
+		IsSender:      true,
+		SharedSecret:  secret,
+		RelayAddress:  "127.0.0.1:8281",
+		RelayPorts:    []string{"8281"},
+		RelayPassword: "pass123",
+		NoPrompt:      true,
+		DisableLocal:  true,
+		Curve:         "siec",
+		GitIgnore:     false,
+	})
+	if err != nil {
+		t.Fatalf("create sender: %v", err)
+	}
+	receiver, err := New(Options{
+		IsSender:      false,
+		SharedSecret:  secret,
+		RelayAddress:  "127.0.0.1:8281",
+		RelayPassword: "pass123",
+		NoPrompt:      true,
+		DisableLocal:  true,
+		Curve:         "siec",
+		Rename:        true,
+	})
+	if err != nil {
+		t.Fatalf("create receiver: %v", err)
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		errCh <- sender.Send(filesInfo, emptyFolders, totalNumberFolders)
+	}()
+	time.Sleep(100 * time.Millisecond)
+	go func() {
+		errCh <- receiver.Receive()
+	}()
+	for i := 0; i < 2; i++ {
+		if err := <-errCh; err != nil {
+			t.Errorf("transfer failed: %v", err)
+		}
+	}
+
+	got, err := os.ReadFile(filepath.Join(receiveDir, "video (1).mkv"))
+	if err != nil {
+		t.Fatalf("read renamed file: %v", err)
+	}
+	if !bytes.Equal(want, got) {
+		t.Errorf("renamed file payload does not match source")
+	}
+	kept, err := os.ReadFile(filepath.Join(receiveDir, fileName))
+	if err != nil {
+		t.Fatalf("read original file: %v", err)
+	}
+	if !bytes.Equal(existing, kept) {
+		t.Errorf("original file was modified")
+	}
+}
+
 func TestCrocEmptyFolder(t *testing.T) {
 	pathName := "../../testEmpty"
 	defer os.RemoveAll(pathName)

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -80,6 +80,23 @@ func Exists(name string) bool {
 	return true
 }
 
+// UnusedFilename returns a filename in folder that does not exist yet,
+// appending " (1)", " (2)", etc. before the extension of name until an
+// unused one is found.
+func UnusedFilename(folder, name string) string {
+	if !Exists(path.Join(folder, name)) {
+		return name
+	}
+	ext := path.Ext(name)
+	base := strings.TrimSuffix(name, ext)
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s (%d)%s", base, i, ext)
+		if !Exists(path.Join(folder, candidate)) {
+			return candidate
+		}
+	}
+}
+
 // stdinReader is shared by all prompts so that piped or typed-ahead
 // answers buffered past one line survive to the next prompt.
 var stdinReader = bufio.NewReader(os.Stdin)

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -137,6 +137,17 @@ func TestExists(t *testing.T) {
 	assert.False(t, Exists("doesnotexist"))
 }
 
+func TestUnusedFilename(t *testing.T) {
+	folder := t.TempDir()
+	assert.Equal(t, "video.mkv", UnusedFilename(folder, "video.mkv"))
+	os.WriteFile(filepath.Join(folder, "video.mkv"), []byte("a"), 0o644)
+	assert.Equal(t, "video (1).mkv", UnusedFilename(folder, "video.mkv"))
+	os.WriteFile(filepath.Join(folder, "video (1).mkv"), []byte("b"), 0o644)
+	assert.Equal(t, "video (2).mkv", UnusedFilename(folder, "video.mkv"))
+	os.WriteFile(filepath.Join(folder, "noext"), []byte("c"), 0o644)
+	assert.Equal(t, "noext (1)", UnusedFilename(folder, "noext"))
+}
+
 func TestMD5HashFile(t *testing.T) {
 	bigFile()
 	defer os.Remove("bigfile.test")


### PR DESCRIPTION
### Summary

This adds a `--rename` flag for receivers. When an incoming file already exists locally with different content, croc saves it as `name (1).ext` (incrementing until unused) instead of prompting to overwrite or resume. Default behavior without the flag is unchanged, as requested in #1182.

### Problem (#1182)

When receiving a file whose name already exists locally, the only choices today are overwriting the local file or skipping the transfer. To keep both files the receiver has to cancel, rename their local copy by hand, and run the transfer again.

### Solution

With `--rename`, the receiver picks the first unused `name (N).ext` in the destination folder and receives into that, printing `Receiving 'video.mkv' as 'video (1).mkv'`. If the existing file is identical to the incoming one, the transfer is skipped as before, so no duplicate is created. The flag also works with `--remember`.

Verified with the new unit test for the name picker, a new integration test (`TestCrocRenameExistingFile`), and manual transfers covering: conflict with `--rename` (new file created, original untouched), `video (1).mkv` also taken (increments to `(2)`), identical file present (skipped, no duplicate), no flags (prompt unchanged), and `--overwrite` (still overwrites in place).

Fixes #1182.