### PR TITLE
Fix/web receiver silent hang

### DIFF
--- a/web/src/protocol/client.test.ts
+++ b/web/src/protocol/client.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The receiver spins up a WASM worker to decrypt data; none of these tests
+// reach a decrypt, so a stub keeps them off the (jsdom-less) Worker path.
+vi.mock("../wasm/client", () => ({
+  wasm: () => ({
+    decrypt: () => Promise.reject(new Error("unused")),
+    decompress: () => Promise.reject(new Error("unused")),
+  }),
+}));
+
+import { DataReceiver } from "./client";
+import type { CrocSocket } from "./transport";
+import type { OfferedFile, ReceiveSink } from "./types";
+
+function failingSocket(error: Error): CrocSocket {
+  return {
+    receive: () => Promise.reject(error),
+  } as unknown as CrocSocket;
+}
+
+function neverSocket(): CrocSocket {
+  return {
+    receive: () => new Promise<Uint8Array>(() => {}),
+  } as unknown as CrocSocket;
+}
+
+const key = new Uint8Array(32);
+
+const file: OfferedFile = {
+  name: "a.txt",
+  folder: ".",
+  path: "a.txt",
+  size: 4,
+  hash: new Uint8Array(),
+};
+
+const sink = {
+  writeAt: () => Promise.resolve(),
+  finalize: () => Promise.resolve(),
+  hash: () => Promise.resolve(new Uint8Array()),
+  commit: () => Promise.resolve(),
+  abort: () => Promise.resolve(),
+} satisfies ReceiveSink;
+
+describe("DataReceiver failure handling", () => {
+  it("rejects a receive requested after a socket already failed", async () => {
+    const receiver = new DataReceiver([failingSocket(new Error("relay closed"))], key, true);
+    // Let the read loop observe the socket failure before we request a file.
+    await Promise.resolve();
+    await expect(receiver.receive(file, sink, () => {})).rejects.toThrow(
+      "relay closed",
+    );
+  });
+
+  it("rejects an in-flight receive when a socket fails", async () => {
+    let reject: (error: Error) => void = () => {};
+    const socket = {
+      receive: () => new Promise<Uint8Array>((_, r) => (reject = r)),
+    } as unknown as CrocSocket;
+    const receiver = new DataReceiver([socket], key, true);
+    const pending = receiver.receive(file, sink, () => {});
+    reject(new Error("relay closed mid-transfer"));
+    await expect(pending).rejects.toThrow("relay closed mid-transfer");
+  });
+
+  it("rejects new receives after stop()", async () => {
+    const receiver = new DataReceiver([neverSocket()], key, true);
+    receiver.stop();
+    await expect(receiver.receive(file, sink, () => {})).rejects.toThrow(
+      "Data receiver stopped",
+    );
+  });
+});

--- a/web/src/protocol/client.ts
+++ b/web/src/protocol/client.ts
@@ -483,9 +483,10 @@ type ActiveReceive = {
   reject(error: Error): void;
 };
 
-class DataReceiver {
+export class DataReceiver {
   private active?: ActiveReceive;
   private stopped = false;
+  private failure?: Error;
 
   constructor(
     private sockets: CrocSocket[],
@@ -500,6 +501,9 @@ class DataReceiver {
     sink: ReceiveSink,
     progress: (fileBytes: number) => void,
   ) {
+    // A data socket can fail before the next file is requested, so surface the
+    // recorded failure instead of waiting for data that will never arrive.
+    if (this.failure) return Promise.reject(this.failure);
     if (this.active) throw new Error("A receive file is already active");
     return new Promise<void>((resolve, reject) => {
       this.active = {
@@ -517,8 +521,7 @@ class DataReceiver {
 
   stop() {
     this.stopped = true;
-    this.active?.reject(new Error("Data receiver stopped"));
-    this.active = undefined;
+    this.fail(new Error("Data receiver stopped"));
   }
 
   private async read(socket: CrocSocket) {
@@ -541,12 +544,16 @@ class DataReceiver {
         await this.accept(position, bytes);
       } catch (error) {
         if (this.stopped) return;
-        const normalized = error instanceof Error ? error : new Error(String(error));
-        this.active?.reject(normalized);
-        this.active = undefined;
         this.stopped = true;
+        this.fail(error instanceof Error ? error : new Error(String(error)));
       }
     }
+  }
+
+  private fail(error: Error) {
+    this.failure ??= error;
+    this.active?.reject(error);
+    this.active = undefined;
   }
 
   private accept(position: number, bytes: Uint8Array) {

--- a/web/src/protocol/storage.download.test.ts
+++ b/web/src/protocol/storage.download.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DownloadDestination } from "./storage";
+import type { OfferedFile } from "./types";
+
+function offered(name: string, size: number): OfferedFile {
+  return { name, folder: ".", path: name, size, hash: new Uint8Array() };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DownloadSink assembly", () => {
+  it("reassembles out-of-order chunks into the original bytes", async () => {
+    const created: Blob[] = [];
+    vi.stubGlobal("URL", {
+      createObjectURL: (blob: Blob) => {
+        created.push(blob);
+        return "blob:test";
+      },
+      revokeObjectURL: () => {},
+    });
+
+    const destination = new DownloadDestination();
+    const sink = await destination.openFile(offered("a.bin", 8));
+    // Deliberately write the second chunk first.
+    await sink.writeAt(4, Uint8Array.of(5, 6, 7, 8));
+    await sink.writeAt(0, Uint8Array.of(1, 2, 3, 4));
+    await sink.finalize();
+    await sink.commit();
+
+    expect(created).toHaveLength(1);
+    const bytes = new Uint8Array(await created[0].arrayBuffer());
+    expect([...bytes]).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("keeps stored chunks independent of the caller's buffer", async () => {
+    const created: Blob[] = [];
+    vi.stubGlobal("URL", {
+      createObjectURL: (blob: Blob) => {
+        created.push(blob);
+        return "blob:test";
+      },
+      revokeObjectURL: () => {},
+    });
+
+    const destination = new DownloadDestination();
+    const sink = await destination.openFile(offered("b.bin", 4));
+    const shared = Uint8Array.of(1, 2, 3, 4);
+    await sink.writeAt(0, shared);
+    // Mutating the caller's buffer after writeAt must not corrupt the download.
+    shared.fill(0);
+    await sink.finalize();
+    await sink.commit();
+
+    const bytes = new Uint8Array(await created[0].arrayBuffer());
+    expect([...bytes]).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/web/src/protocol/storage.ts
+++ b/web/src/protocol/storage.ts
@@ -119,7 +119,9 @@ export class DirectoryDestination implements ReceiveDestination {
 }
 
 class DownloadSink implements ReceiveSink {
-  private chunks = new Map<number, Uint8Array>();
+  // Stored chunks own their backing ArrayBuffer (writeAt copies via slice()),
+  // which lets finalize() hand them straight to Blob without a second copy.
+  private chunks = new Map<number, Uint8Array<ArrayBuffer>>();
   private blob?: Blob;
   private committed = false;
 
@@ -133,9 +135,13 @@ class DownloadSink implements ReceiveSink {
   }
 
   async finalize() {
+    // Chunks are already private copies (see writeAt); hand them straight to
+    // Blob, which copies its parts internally. Wrapping each one in
+    // Uint8Array.from() first allocated a redundant second copy of the whole
+    // file before the Blob was even built.
     const ordered = [...this.chunks.entries()]
       .sort(([left], [right]) => left - right)
-      .map(([, bytes]) => Uint8Array.from(bytes).buffer);
+      .map(([, bytes]) => bytes);
     this.blob = new Blob(ordered, { type: "application/octet-stream" });
     this.chunks.clear();
   }


### PR DESCRIPTION
Quick note for review 👇

Heads-up that the web client tests don't run in CI (the workflow only does
`go test ./...`), so these two fixes ship with their own Vitest coverage you can
run locally:


The hang was the one that bit me: if a data socket drops before the first file
is requested, `receiveFiles()` used to wait on a promise that never settled —
and the "Cancel receive" button is hidden at that point, so the only way out was
a page reload. The new test times out against `main` and passes with the fix,
which is the clearest way to see it.

Both changes are independent — happy to split them into two PRs if you'd prefer
to review/merge them separately. And I have a couple more small fixes queued for
the fresh web code (a nil-deref guard on `os.Stdin.Stat()`, a WASM handle leak on
cancelled transfers) that I'll send as separate PRs so this one stays focused.

Thanks for croc — the WASM-reuse approach for the browser client is really nice.
