### PR TITLE
fix: harden existing remembered config permissions

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -600,6 +600,30 @@ func makeTempFileWithString(s string) (fnames []string, err error) {
 	return
 }
 
+// writePrivateConfigFile writes configuration only after enforcing owner-only
+// permissions. os.WriteFile's permission argument applies only to newly created
+// files, so it does not harden configs created by older croc versions.
+func writePrivateConfigFile(name string, data []byte) (err error) {
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := f.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	if err = f.Chmod(0o600); err != nil {
+		return err
+	}
+	if err = f.Truncate(0); err != nil {
+		return err
+	}
+	_, err = f.Write(data)
+	return err
+}
+
 func saveConfig(c *cli.Context, crocOptions croc.Options) {
 	if c.Bool("remember") {
 		configFile := getSendConfigFile(true)
@@ -624,7 +648,7 @@ func saveConfig(c *cli.Context, crocOptions croc.Options) {
 			log.Error(err)
 			return
 		}
-		err = os.WriteFile(configFile, bConfig, 0o600)
+		err = writePrivateConfigFile(configFile, bConfig)
 		if err != nil {
 			log.Error(err)
 			return
@@ -786,7 +810,7 @@ Or you can go back to the classic croc behavior by enabling classic mode:
 			log.Error(err)
 			return
 		}
-		err = os.WriteFile(configFile, bConfig, 0o600)
+		err = writePrivateConfigFile(configFile, bConfig)
 		if err != nil {
 			log.Error(err)
 			return

--- a/src/cli/cli_test.go
+++ b/src/cli/cli_test.go
@@ -2,11 +2,61 @@ package cli
 
 import (
 	"flag"
+	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/schollz/cli/v2"
 )
+
+func TestWritePrivateConfigFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing bool
+	}{
+		{name: "new config"},
+		{name: "existing permissive config", existing: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.json")
+			if tt.existing {
+				if err := os.WriteFile(configPath, []byte("old secret"), 0o644); err != nil {
+					t.Fatalf("create existing config: %v", err)
+				}
+				if err := os.Chmod(configPath, 0o644); err != nil {
+					t.Fatalf("make existing config permissive: %v", err)
+				}
+			}
+
+			want := []byte(`{"RelayPassword":"new secret"}`)
+			if err := writePrivateConfigFile(configPath, want); err != nil {
+				t.Fatalf("write private config: %v", err)
+			}
+
+			got, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("read config: %v", err)
+			}
+			if string(got) != string(want) {
+				t.Fatalf("config contents = %q, want %q", got, want)
+			}
+
+			if runtime.GOOS != "windows" {
+				info, err := os.Stat(configPath)
+				if err != nil {
+					t.Fatalf("stat config: %v", err)
+				}
+				if gotMode := info.Mode().Perm(); gotMode != 0o600 {
+					t.Fatalf("config permissions = %o, want 600", gotMode)
+				}
+			}
+		})
+	}
+}
 
 // determinePass should trim a pass from --pass/CROC_PASS, not just from a file.
 func TestDeterminePassTrimsEnvValue(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #1187: make the `0600` protection effective for configuration files created by older croc versions.

`os.WriteFile(name, data, 0o600)` uses the permission argument only when it creates a file. When `send.json` or `receive.json` already exists with the previous `0644` mode, rewriting it preserves that permissive mode, so remembered relay passwords remain readable by other local users after an upgrade.

This PR:

- adds one private config writer shared by send and receive;
- opens the file without truncating it first;
- applies `0600` to the open file before writing any new secret data;
- truncates and writes only after the permission change succeeds;
- preserves write and close errors;
- covers both a new config and migration of an existing `0644` config.

## Verification

- `go test ./src/cli`
- `go test ./src/cli -run '^TestWritePrivateConfigFile$' -count=10`
- `go vet ./...`
- `npm test -- --run` in `web/` (24 tests)
- reconnect/control tests run individually and pass

The full Go suite on this Windows machine reaches an existing `TestRunCtx` network-ordering failure after other `src/croc` integration tests; `TestRunCtx` and the reconnect tests pass individually. This change only touches `src/cli`.
