### PR TITLE
fix: return error instead of panic in EncryptChaCha

### DIFF
--- a/src/crypt/crypt.go
+++ b/src/crypt/crypt.go
@@ -100,7 +100,7 @@ func NewArgon2(passphrase []byte, usersalt []byte) (aead cipher.AEAD, salt []byt
 func EncryptChaCha(plaintext []byte, aead cipher.AEAD) (encrypted []byte, err error) {
 	nonce := make([]byte, aead.NonceSize(), aead.NonceSize()+len(plaintext)+aead.Overhead())
 	if _, err := rand.Read(nonce); err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	// Encrypt the message and append the ciphertext to the nonce.


### PR DESCRIPTION
If `crypto/rand` fails during nonce generation, `EncryptChaCha` currently panics instead of returning the error. The function already returns `error`, so this changes the panic to `return nil, err`.