### PR TITLE
fix: reject receive paths through symlink parents

### DIFF
--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -712,17 +712,7 @@ func validateReceiveMetadata(files []FileInfo, emptyFolders []FileInfo) ([]FileI
 }
 
 func rejectSymlinkDestination(pathToFile string) error {
-	info, err := os.Lstat(pathToFile)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to open symlink destination: '%s'", pathToFile)
-	}
-	return nil
+	return utils.RejectSymlinkPath(".", pathToFile)
 }
 
 // helper function to walk each subfolder and parses against an ignore file.
@@ -1928,6 +1918,9 @@ func (c *Client) createEmptyFolder(i int) (err error) {
 		return
 	}
 	c.EmptyFoldersToTransfer[i].FolderRemote = folderRemote
+	if err = utils.RejectSymlinkPath(".", folderRemote); err != nil {
+		return
+	}
 	err = os.MkdirAll(c.EmptyFoldersToTransfer[i].FolderRemote, os.ModePerm)
 	if err != nil {
 		return
@@ -2385,6 +2378,9 @@ func (c *Client) recipientInitializeFile() (err error) {
 	c.FilesToTransfer[c.FilesToTransferCurrentNum].Name = path.Base(pathToFile)
 	folderForFile, _ := filepath.Split(pathToFile)
 	folderForFileBase := filepath.Base(folderForFile)
+	if err = utils.RejectSymlinkPath(".", folderForFile); err != nil {
+		return
+	}
 	if folderForFileBase != "." && folderForFileBase != "" {
 		if err := os.MkdirAll(folderForFile, os.ModePerm); err != nil {
 			log.Errorf("can't create %s: %v", folderForFile, err)
@@ -2532,6 +2528,9 @@ func (c *Client) createEmptyFileAndFinish(fileInfo FileInfo, i int) (err error) 
 	}
 	fileInfo.FolderRemote = folderRemote
 	fileInfo.Name = path.Base(pathToFile)
+	if err = utils.RejectSymlinkPath(".", filepath.Dir(pathToFile)); err != nil {
+		return
+	}
 	if !utils.Exists(fileInfo.FolderRemote) {
 		err = os.MkdirAll(fileInfo.FolderRemote, os.ModePerm)
 		if err != nil {

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -330,6 +330,61 @@ func TestHostileExistingSymlinkDestinationRejected(t *testing.T) {
 	assert.Equal(t, original, got)
 }
 
+func TestHostileExistingSymlinkParentRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on some Windows setups")
+	}
+
+	tmpDir := t.TempDir()
+	receiveDir := filepath.Join(tmpDir, "receive")
+	outsideDir := filepath.Join(tmpDir, "outside")
+	if err := os.MkdirAll(receiveDir, 0o755); err != nil {
+		t.Fatalf("mkdir receive dir: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("mkdir outside dir: %v", err)
+	}
+	if err := os.Symlink(outsideDir, filepath.Join(receiveDir, "nested")); err != nil {
+		t.Fatalf("create symlink parent: %v", err)
+	}
+
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(receiveDir); err != nil {
+		t.Fatalf("chdir receive dir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalCwd); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	}()
+
+	client := &Client{
+		Options: Options{
+			SendingText: true,
+			Overwrite:   true,
+		},
+		FilesHasFinished: make(map[int]struct{}),
+		FilesToTransfer: []FileInfo{
+			{
+				Name:         "payload.txt",
+				FolderRemote: "nested",
+				Size:         1,
+				Mode:         0o644,
+			},
+		},
+	}
+
+	err = client.recipientInitializeFile()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "symlink destination path component")
+
+	_, err = os.Stat(filepath.Join(outsideDir, "payload.txt"))
+	assert.True(t, os.IsNotExist(err), "receive must not write through a symlink parent")
+}
+
 func TestCrocReadme(t *testing.T) {
 	defer os.Remove("README.md")
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -761,6 +761,47 @@ func pathWithin(parent string, child string) bool {
 	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
+// RejectSymlinkPath rejects existing symlinks in target and its path
+// components below root. This prevents writes through a pre-existing symlink
+// from escaping the intended destination directory.
+func RejectSymlinkPath(root, target string) error {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("failed to resolve destination root: %w", err)
+	}
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return fmt.Errorf("failed to resolve destination path: %w", err)
+	}
+
+	rel, err := filepath.Rel(rootAbs, targetAbs)
+	if err != nil {
+		return fmt.Errorf("failed to resolve destination path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return fmt.Errorf("destination path escapes root: '%s'", target)
+	}
+	if rel == "." {
+		return nil
+	}
+
+	current := rootAbs
+	for _, component := range strings.Split(rel, string(os.PathSeparator)) {
+		current = filepath.Join(current, component)
+		info, statErr := os.Lstat(current)
+		if os.IsNotExist(statErr) {
+			return nil
+		}
+		if statErr != nil {
+			return fmt.Errorf("failed to inspect destination path '%s': %w", current, statErr)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to open symlink destination path component: '%s'", current)
+		}
+	}
+	return nil
+}
+
 func UnzipDirectory(destination string, source string) error {
 	archive, err := zip.OpenReader(source)
 	if err != nil {
@@ -774,6 +815,10 @@ func UnzipDirectory(destination string, source string) error {
 	for i, f := range archive.File {
 		filePath, pathErr := resolveUnzipPath(destination, f.Name)
 		if pathErr != nil {
+			log.Errorf("Invalid file path %s: %v\n", f.Name, pathErr)
+			return fmt.Errorf("invalid file path in zip entry %q: %w", f.Name, pathErr)
+		}
+		if pathErr = RejectSymlinkPath(destination, filePath); pathErr != nil {
 			log.Errorf("Invalid file path %s: %v\n", f.Name, pathErr)
 			return fmt.Errorf("invalid file path in zip entry %q: %w", f.Name, pathErr)
 		}
@@ -799,6 +844,9 @@ func UnzipDirectory(destination string, source string) error {
 		}
 
 		if f.FileInfo().IsDir() {
+			if err := RejectSymlinkPath(destination, filePath); err != nil {
+				return fmt.Errorf("refusing to extract zip entry %q: %w", f.Name, err)
+			}
 			if err := os.MkdirAll(filePath, os.ModePerm); err != nil {
 				log.Error(err)
 			}
@@ -808,6 +856,9 @@ func UnzipDirectory(destination string, source string) error {
 		if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
 			log.Error(err)
 			continue
+		}
+		if err := RejectSymlinkPath(destination, filePath); err != nil {
+			return fmt.Errorf("refusing to extract zip entry %q: %w", f.Name, err)
 		}
 
 		// check if file exists

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -513,6 +514,37 @@ func TestUnzipDirectoryRejectsPathTraversal(t *testing.T) {
 
 	_, statErr = os.Stat(filepath.Join(extractDir, "safe", "file.txt"))
 	assert.True(t, os.IsNotExist(statErr), "pre-validation should prevent partial extraction")
+}
+
+func TestUnzipDirectoryRejectsSymlinkParentEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires elevated privileges on some Windows setups")
+	}
+
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "symlink-parent.zip")
+	extractDir := filepath.Join(tmpDir, "extract")
+	outsideDir := filepath.Join(tmpDir, "outside")
+	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+		t.Fatalf("Failed to create extraction directory: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0o755); err != nil {
+		t.Fatalf("Failed to create outside directory: %v", err)
+	}
+	if err := os.Symlink(outsideDir, filepath.Join(extractDir, "linked")); err != nil {
+		t.Fatalf("Failed to create symlink parent: %v", err)
+	}
+	if err := createZipWithEntries(zipPath, []zipTestEntry{
+		{name: "linked/escaped.txt", content: "escape"},
+	}); err != nil {
+		t.Fatalf("Failed to create malicious zip: %v", err)
+	}
+
+	err := UnzipDirectory(extractDir, zipPath)
+	assert.ErrorContains(t, err, "symlink destination path component")
+
+	_, statErr := os.Stat(filepath.Join(outsideDir, "escaped.txt"))
+	assert.True(t, os.IsNotExist(statErr), "zip extraction must not write through a symlink parent")
 }
 
 func TestResolveUnzipPathRejectsNonLocalEntries(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject existing symlinks in every destination path component, not only the final filename
- apply the guard to regular files, empty files/folders, transferred symlinks, and automatic ZIP extraction
- pre-validate ZIP entries before extraction and re-check immediately before writes
- add regression coverage for direct receives and ZIP extraction through symlinked parent directories

## Why

The receiver already rejected a final destination that was a symlink, but an existing parent symlink was still followed. For example, if `nested` pointed outside the receive directory, a peer-provided `nested/payload.txt` could be written outside that directory. Automatic ZIP extraction had the same gap.

The shared guard resolves the target relative to the intended root and walks each existing component with `Lstat`, rejecting symlinks before any write.

## Validation

- `go vet ./...`
- focused receive/unzip security tests pass
- all non-`src/croc` packages pass in `go test ./...`
- the full Windows run reaches the existing `TestCrocSymlink` privilege failure (`A required privilege is not held by the client`); Linux CI exercises the new symlink regression tests