### PR TITLE
docs: add Croc GUI to app list

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ There are F-Droid apps available:
 - [crocgui](https://f-droid.org/packages/com.github.howeyc.crocgui/) — original port (Go, basic UI)
 - [croc-app](https://f-droid.org/en/packages/com.dking.crocapp/) — native Kotlin/Jetpack Compose client with a modern, mobile-first interface
 - [FlCroc](https://github.com/576576/FlCroc) is a cross-platform Flutter GUI (Android, Windows, Linux) that wraps the `croc` binary as its transfer core.
+- [Croc GUI](https://github.com/interfluve-wav/croc-gui) is an unofficial desktop GUI for macOS, Windows, and Linux that bundles the `croc` binary for drag-and-drop transfers, QR codes, LAN mode, and relay/proxy options.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Adds Croc GUI to the README app list as an unofficial desktop GUI for macOS, Windows, and Linux.
- Notes that it wraps/bundles the upstream croc binary and links to the project.

## Test Plan
- Documentation-only change.
- Ran: git diff --check