### PR TITLE
Add NoEncrypt option to CLI and configuration structures

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -76,6 +76,7 @@ func newApp() *cli.App {
 				&cli.StringFlag{Name: "text", Aliases: []string{"t"}, Usage: "send some text"},
 				&cli.BoolFlag{Name: "no-local", Usage: "disable local relay when sending"},
 				&cli.BoolFlag{Name: "no-multi", Usage: "disable multiplexing"},
+				&cli.BoolFlag{Name: "no-encrypt", Usage: "disable payload encryption for trusted networks"},
 				&cli.BoolFlag{Name: "git", Usage: "enable .gitignore respect / don't send ignored files"},
 				&cli.IntFlag{Name: "port", Value: 9009, Usage: "base port for the relay"},
 				&cli.IntFlag{Name: "transfers", Value: 4, Usage: "number of ports to use for transfers"},

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -381,6 +381,7 @@ func send(c *cli.Context) (err error) {
 		RelayPorts:        ports,
 		Ask:               c.Bool("ask"),
 		NoMultiplexing:    c.Bool("no-multi"),
+		NoEncrypt:         c.Bool("no-encrypt"),
 		RelayPassword:     determinePass(c),
 		SendingText:       c.String("text") != "",
 		NoCompress:        c.Bool("no-compress"),

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -2550,6 +2550,7 @@ func (c *Client) updateIfSenderChannelSecured() (err error) {
 			TotalNumberFolders:     c.TotalNumberFolders,
 			SendingText:            c.Options.SendingText,
 			NoCompress:             c.Options.NoCompress,
+			NoEncrypt:              c.Options.NoEncrypt,
 			HashAlgorithm:          c.Options.HashAlgorithm,
 			ReconnectVersion:       c.reconnectVersion,
 			NextReconnectRoom:      nextReconnectRoom,

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -3152,27 +3152,26 @@ func (c *Client) sendData(i int, dataConn *comm.Comm, fread *os.File, attempt *t
 					// log.Debugf("sending chunk %d", pos)
 					posByte := make([]byte, 8)
 					binary.LittleEndian.PutUint64(posByte, pos)
-					var err error
-					var dataToSend []byte
-					if c.Options.NoCompress {
-						dataToSend, err = crypt.Encrypt(
-							append(posByte, data[:n]...),
-							c.Key,
-						)
-					} else {
-						dataToSend, err = crypt.Encrypt(
-							compress.Compress(
-								append(posByte, data[:n]...),
-							),
-							c.Key,
-						)
-					}
-					if err != nil {
-						attempt.report(err)
-						return
-					}
 
+					payload := append(posByte, data[:n]...)
+
+					if !c.Options.NoCompress {
+					    payload = compress.Compress(payload)
+					}
+					
+					if c.Options.NoEncrypt {
+					    dataToSend = payload
+					} else {
+					    dataToSend, err = crypt.Encrypt(payload, c.Key)
+					}
+					
+					if err != nil {
+					    attempt.report(err)
+					    return
+					}
+					
 					err = dataConn.Send(dataToSend)
+
 					if err != nil {
 						if c.ctxErr() == nil {
 							attempt.report(transferDisconnectError{err: err})

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -87,6 +87,7 @@ type Options struct {
 	Stdout            bool
 	NoPrompt          bool
 	NoMultiplexing    bool
+	NoEncrypt 		  bool
 	DisableLocal      bool
 	OnlyLocal         bool
 	IgnoreStdin       bool

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -3163,6 +3163,7 @@ func (c *Client) sendData(i int, dataConn *comm.Comm, fread *os.File, attempt *t
 				
 				    // Encrypt only when encryption is enabled.
 				    var dataToSend []byte
+					var err error
 				
 				    if c.Options.NoEncrypt {
 				        dataToSend = payload

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -3011,12 +3011,15 @@ func (c *Client) receiveData(i int, dataConn *comm.Comm, attempt *transferAttemp
 			log.Trace("got ping")
 			continue
 		}
-
-		data, err = crypt.Decrypt(data, c.Key)
-		if err != nil {
-			attempt.report(err)
-			return
+		
+		if !c.Options.NoEncrypt {
+			data, err = crypt.Decrypt(data, c.Key)
+			if err != nil {
+				attempt.report(err)
+				return
+			}
 		}
+		
 		if !c.Options.NoCompress {
 			data, err = compress.Decompress(data, maxDecompressedChunkSize)
 			if err != nil {

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -2054,6 +2054,7 @@ func (c *Client) processMessageFileInfo(m message.Message) (done bool, err error
 	}
 	c.Options.SendingText = senderInfo.SendingText
 	c.Options.NoCompress = senderInfo.NoCompress
+	c.Options.NoEncrypt = senderInfo.NoEncrypt
 	c.Options.HashAlgorithm = senderInfo.HashAlgorithm
 	c.peerReconnectVersion = senderInfo.ReconnectVersion
 	c.nextReconnectRoom = senderInfo.NextReconnectRoom

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -234,6 +234,7 @@ type SenderInfo struct {
 	Ask                    bool
 	SendingText            bool
 	NoCompress             bool
+	NoEncrypt              bool
 	HashAlgorithm          string
 	ReconnectVersion       int
 	NextReconnectRoom      string

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -3149,38 +3149,43 @@ func (c *Client) sendData(i int, dataConn *comm.Comm, fread *os.File, attempt *t
 				}
 				c.mutex.Unlock()
 				if usableChunk {
-					// log.Debugf("sending chunk %d", pos)
-					posByte := make([]byte, 8)
-					binary.LittleEndian.PutUint64(posByte, pos)
-
-					payload := append(posByte, data[:n]...)
-
-					if !c.Options.NoCompress {
-					    payload = compress.Compress(payload)
-					}
-					
-					if c.Options.NoEncrypt {
-					    dataToSend = payload
-					} else {
-					    dataToSend, err = crypt.Encrypt(payload, c.Key)
-					}
-					
-					if err != nil {
-					    attempt.report(err)
-					    return
-					}
-					
-					err = dataConn.Send(dataToSend)
-
-					if err != nil {
-						if c.ctxErr() == nil {
-							attempt.report(transferDisconnectError{err: err})
-						}
-						return
-					}
-					c.bar.Add(n)
-					c.TotalSent += int64(n)
-					// time.Sleep(100 * time.Millisecond)
+				    // log.Debugf("sending chunk %d", pos)
+				
+				    posByte := make([]byte, 8)
+				    binary.LittleEndian.PutUint64(posByte, pos)
+				
+				    // Build the payload.
+				    payload := append(posByte, data[:n]...)
+				
+				    if !c.Options.NoCompress {
+				        payload = compress.Compress(payload)
+				    }
+				
+				    // Encrypt only when encryption is enabled.
+				    var dataToSend []byte
+				
+				    if c.Options.NoEncrypt {
+				        dataToSend = payload
+				    } else {
+				        dataToSend, err = crypt.Encrypt(payload, c.Key)
+				    }
+				
+				    if err != nil {
+				        attempt.report(err)
+				        return
+				    }
+				
+				    err = dataConn.Send(dataToSend)
+				
+				    if err != nil {
+				        if c.ctxErr() == nil {
+				            attempt.report(transferDisconnectError{err: err})
+				        }
+				        return
+				    }
+				    c.bar.Add(n)
+				    c.TotalSent += int64(n)
+				    // time.Sleep(100 * time.Millisecond)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #1222 
## Summary

Added an optional --no-encrypt mode to croc for file transfers over trusted networks such as LAN or direct P2P Ethernet connections.

## Motivation

For high-speed trusted network transfers, payload encryption can introduce additional CPU overhead and may reduce transfer performance.

croc already provides useful features such as simple peer-to-peer transfer and resumable file transfers. This change allows users to retain those features while optionally disabling payload encryption when encryption is not required.

## Changes

* Added a new --no-encrypt CLI option.
* Added NoEncrypt to the transfer options.
* Added encryption mode information to SenderInfo so the receiver can determine whether payload encryption is enabled.
* Updated the sender to skip payload encryption when --no-encrypt is enabled.
* Updated the receiver to skip payload decryption for unencrypted transfers.
* Kept the existing PAKE/session setup unchanged.
* Kept encrypted transfers as the default behavior.
* Preserved the existing compression and resumable transfer functionality.
* Added/updated tests for encrypted and unencrypted transfer scenarios.
* Updated documentation for the new option.

## Usage

Existing encrypted transfer remains unchanged:

bash
croc send <file>


For a trusted network:

bash
croc send --no-encrypt <file>


The receiver does not need to specify an additional option. The encryption mode is communicated by the sender as part of the transfer metadata.

## Security Consideration

--no-encrypt is explicitly opt-in and should only be used on trusted networks where payload confidentiality is not required.

The default behavior remains unchanged, with payload encryption enabled.

## Validation

Validated the following scenarios:

* Normal encrypted file transfer
* Unencrypted file transfer
* Unencrypted transfer with compression enabled
* Unencrypted transfer with compression disabled
* Resumable unencrypted transfer
* File integrity after transfer
* Existing encrypted transfer behavior remains unchanged 