### PR TITLE
feat: add --json machine-readable event output

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -17,6 +17,8 @@ import (
 	"github.com/schollz/croc/v11/src/codephrase"
 	"github.com/schollz/croc/v11/src/comm"
 	"github.com/schollz/croc/v11/src/croc"
+	"github.com/schollz/croc/v11/src/events"
+	"github.com/schollz/croc/v11/src/events"
 	"github.com/schollz/croc/v11/src/models"
 	"github.com/schollz/croc/v11/src/storeclient"
 	"github.com/schollz/croc/v11/src/tcp"
@@ -34,7 +36,11 @@ func Run() (err error) {
 	// use all of the processors
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	return newApp().Run(os.Args)
+	err = newApp().Run(os.Args)
+	if err != nil && events.Enabled() {
+		events.Error(err)
+	}
+	return
 }
 
 func newApp() *cli.App {
@@ -137,6 +143,7 @@ func newApp() *cli.App {
 		&cli.BoolFlag{Name: "rename", Usage: "receive files that already exist under a new name instead of prompting"},
 		&cli.BoolFlag{Name: "testing", Usage: "flag for testing purposes"},
 		&cli.BoolFlag{Name: "quiet", Usage: "disable all output"},
+		&cli.BoolFlag{Name: "json", Usage: "output machine-readable JSON events to stderr"},
 		&cli.BoolFlag{Name: "disable-clipboard", Usage: "disable copy to clipboard"},
 		&cli.BoolFlag{Name: "extended-clipboard", Usage: "copy full command with secret as env variable to clipboard"},
 		&cli.StringFlag{Name: "revoke", Usage: "revoke a stored transfer using its local sender receipt"},
@@ -399,6 +406,7 @@ func send(c *cli.Context) (err error) {
 		Quiet:             c.Bool("quiet"),
 		DisableClipboard:  c.Bool("disable-clipboard"),
 		ExtendedClipboard: c.Bool("extended-clipboard"),
+		Events:            c.Bool("json"),
 	}
 	if crocOptions.RelayAddress != models.DEFAULT_RELAY {
 		crocOptions.RelayAddress6 = ""
@@ -567,6 +575,11 @@ Or you can go back to the classic croc behavior by enabling classic mode:
 		return
 	}
 
+	if c.Bool("json") {
+		events.Version(Version)
+		events.Code(crocOptions.SharedSecret)
+	}
+
 	// save the config
 	saveConfig(c, crocOptions)
 	err = cr.Send(minimalFileInfos, emptyFoldersToTransfer, totalNumberFolders)
@@ -693,6 +706,7 @@ func receive(c *cli.Context) (err error) {
 		Quiet:             c.Bool("quiet"),
 		DisableClipboard:  c.Bool("disable-clipboard"),
 		ExtendedClipboard: c.Bool("extended-clipboard"),
+		Events:            c.Bool("json"),
 	}
 	if crocOptions.RelayAddress != models.DEFAULT_RELAY {
 		crocOptions.RelayAddress6 = ""
@@ -821,6 +835,10 @@ Or you can go back to the classic croc behavior by enabling classic mode:
 	cr, err := croc.New(crocOptions)
 	if err != nil {
 		return
+	}
+
+	if c.Bool("json") {
+		events.Version(Version)
 	}
 
 	// save the config

--- a/src/cli/store.go
+++ b/src/cli/store.go
@@ -15,6 +15,8 @@ import (
 	"github.com/rivo/uniseg"
 	"github.com/schollz/croc/v11/internal/cli"
 	"github.com/schollz/croc/v11/src/croc"
+	"github.com/schollz/croc/v11/src/events"
+	"github.com/schollz/croc/v11/src/events"
 	storeapi "github.com/schollz/croc/v11/src/store"
 	"github.com/schollz/croc/v11/src/storeclient"
 	"github.com/schollz/croc/v11/src/storecrypto"
@@ -247,9 +249,12 @@ func sendStored(c *cli.Context) error {
 		strings.TrimSpace(c.String("store-url")),
 		paths,
 		storeclient.UploadOptions{Downloads: downloads, Expiration: expiration},
-		storedCallbacks(c.Bool("quiet")),
+		storedCallbacks(c.Bool("quiet") && !c.Bool("json")),
 	)
-	if !c.Bool("quiet") {
+	if c.Bool("json") {
+		events.Version(Version)
+	}
+	if !c.Bool("quiet") && !c.Bool("json") {
 		fmt.Fprintln(os.Stderr)
 	}
 	if err != nil {
@@ -270,6 +275,15 @@ func sendStored(c *cli.Context) error {
 		ExpiresAt:   result.ExpiresAt,
 	}); err != nil {
 		return fmt.Errorf("save stored-transfer revoke receipt: %w", err)
+	}
+	if c.Bool("json") {
+		events.Store(
+			browserURL,
+			token,
+			result.ExpiresAt.UTC().Format(time.RFC3339),
+			result.Share.ID,
+		)
+		return nil
 	}
 	downloadLimit := fmt.Sprintf("%d verified downloads", result.Downloads)
 	if result.Downloads == 1 {

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -38,6 +38,8 @@ import (
 	"github.com/schollz/croc/v11/src/comm"
 	"github.com/schollz/croc/v11/src/compress"
 	"github.com/schollz/croc/v11/src/crypt"
+	"github.com/schollz/croc/v11/src/events"
+	"github.com/schollz/croc/v11/src/events"
 	"github.com/schollz/croc/v11/src/message"
 	"github.com/schollz/croc/v11/src/models"
 	"github.com/schollz/croc/v11/src/pakekey"
@@ -109,6 +111,7 @@ type Options struct {
 	Quiet             bool
 	DisableClipboard  bool
 	ExtendedClipboard bool
+	Events            bool
 }
 
 type SimpleMessage struct {
@@ -173,6 +176,7 @@ type Client struct {
 	senderRouteReady        chan struct{}
 	senderRouteReadyOnce    sync.Once
 	transferStarted         atomic.Bool
+	transferComplete        atomic.Bool
 	// localRelayPort is the control port of the ephemeral local relay started by
 	// setupLocalRelay(). It is captured before any goroutines that might
 	// overwrite c.Options.RelayPorts are launched.
@@ -188,6 +192,14 @@ type Client struct {
 	quit                     chan bool
 	finishedNum              int
 	numberOfTransferredFiles int
+
+	// progress event tracking (--json)
+	progMu          sync.Mutex
+	progFileNum     int
+	progBytes       int64
+	progLastBytes   int64
+	progLastEmit    time.Time
+	progEmitStarted bool
 
 	// ctx.go for graceful shutdown
 	*stop
@@ -253,6 +265,14 @@ func New(ops Options) (c *Client, err error) {
 		if err == nil {
 			os.Stderr = devNull
 		}
+	}
+
+	// enable machine-readable JSON events (--json) when requested
+	if c.Options.Events {
+		termui.MuteHumanOutput(true)
+		events.Enable(os.Stderr)
+	} else {
+		termui.MuteHumanOutput(false)
 	}
 
 	codeComponents, err := codephrase.Parse(c.Options.SharedSecret)
@@ -503,7 +523,10 @@ func (c *Client) activeTransferStarted() bool {
 }
 
 func (c *Client) markTransferStarted() {
-	c.transferStarted.Store(true)
+	if c.transferStarted.Swap(true) {
+		return
+	}
+	c.emitPhase("transferring", "transferring files")
 }
 
 func (c *Client) markSenderRouteReady() {
@@ -1034,16 +1057,18 @@ func (c *Client) sendCollectFiles(filesInfo []FileInfo) (err error) {
 			c.Options.HashAlgorithm = "xxhash"
 		}
 
-		c.FilesToTransfer[i].Hash, err = c.stop.hash(fullPath, c.Options.HashAlgorithm, fileInfo.Size > 1e7)
+		c.FilesToTransfer[i].Hash, err = c.stop.hash(fullPath, c.Options.HashAlgorithm, !c.Options.Events && fileInfo.Size > 1e7)
 		log.Debugf("hashed %s to %x using %s", fullPath, c.FilesToTransfer[i].Hash, c.Options.HashAlgorithm)
 		totalFilesSize += fileInfo.Size
 		if err != nil {
 			return
 		}
 		log.Debugf("file %d info: %+v", i, c.FilesToTransfer[i])
-		fmt.Fprintf(os.Stderr, "\r                                 ")
-		output, _ := termui.Output(os.Stderr)
-		fmt.Fprintf(output, "\rSending %d files (%s)", i, utils.ByteCountDecimal(totalFilesSize))
+		if !c.Options.Events {
+			fmt.Fprintf(os.Stderr, "\r                                 ")
+			output, _ := termui.Output(os.Stderr)
+			fmt.Fprintf(output, "\rSending %d files (%s)", i, utils.ByteCountDecimal(totalFilesSize))
+		}
 	}
 	log.Debugf("longestFilename: %+v", c.longestFilename)
 	fname := fmt.Sprintf("%d files", len(c.FilesToTransfer))
@@ -1062,6 +1087,9 @@ func (c *Client) sendCollectFiles(filesInfo []FileInfo) (err error) {
 		}
 	}
 
+	if c.Options.Events {
+		return
+	}
 	fmt.Fprintf(os.Stderr, "\r                                 ")
 	output, colorEnabled := termui.Output(os.Stderr)
 	if displayName != "" {
@@ -1407,6 +1435,7 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 	c.EmptyFoldersToTransfer = emptyFoldersToTransfer
 	c.TotalNumberFolders = totalNumberFolders
 	c.TotalNumberOfContents = len(filesInfo)
+	c.emitPhase("hashing", "hashing files")
 	err = c.sendCollectFiles(filesInfo)
 	if err != nil {
 		return
@@ -1419,18 +1448,22 @@ func (c *Client) Send(filesInfo []FileInfo, emptyFoldersToTransfer []FileInfo, t
 		flags.WriteString("--pass " + c.Options.RelayPassword + " ")
 	}
 	webURL := webReceiveURL(c.Options.SharedSecret)
-	output, colorEnabled := termui.Output(os.Stderr)
-	fmt.Fprint(output, formatSendInstructions(c.Options.SharedSecret, flags.String(), webURL, colorEnabled))
-	if !c.Options.DisableClipboard {
-		clipboardText := formatClipboardText(c.Options.SharedSecret, flags.String(), c.Options.ExtendedClipboard)
-		copyToClipboard(clipboardText, c.Options.Quiet, c.Options.ExtendedClipboard)
-	}
-	if c.Options.ShowQrCode {
-		showReceiveCommandQrCode(webURL)
-	}
-	if c.Options.Ask {
-		machid, _ := machineid.ID()
-		fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)
+	if c.Options.Events {
+		c.emitPhase("connecting", "connecting to relay")
+	} else {
+		output, colorEnabled := termui.Output(os.Stderr)
+		fmt.Fprint(output, formatSendInstructions(c.Options.SharedSecret, flags.String(), webURL, colorEnabled))
+		if !c.Options.DisableClipboard {
+			clipboardText := formatClipboardText(c.Options.SharedSecret, flags.String(), c.Options.ExtendedClipboard)
+			copyToClipboard(clipboardText, c.Options.Quiet, c.Options.ExtendedClipboard)
+		}
+		if c.Options.ShowQrCode {
+			showReceiveCommandQrCode(webURL)
+		}
+		if c.Options.Ask {
+			machid, _ := machineid.ID()
+			fmt.Fprintf(os.Stderr, "\rYour machine ID is '%s'\n", machid)
+		}
 	}
 	// c.spinner.Suffix = " waiting for recipient..."
 	// c.spinner.Start()
@@ -1626,8 +1659,12 @@ func (c *Client) discoverReceivePeers() (discoveries []peerdiscovery.Discovered)
 func (c *Client) Receive() (err error) {
 	go c.stop.done()
 	defer c.stop.Cancel()
-	output, _ := termui.Output(os.Stderr)
-	fmt.Fprint(output, "connecting...")
+	if c.Options.Events {
+		c.emitPhase("connecting", "connecting to relay")
+	} else {
+		output, _ := termui.Output(os.Stderr)
+		fmt.Fprint(output, "connecting...")
+	}
 	// recipient will look for peers first
 	// and continue if it doesn't find any within 100 ms
 	usingLocal := false
@@ -1872,8 +1909,10 @@ func (c *Client) Receive() (err error) {
 		c.Options.RelayPorts = []string{c.Options.RelayPorts[0]}
 	}
 	log.Debug("exchanged header message")
-	output, _ = termui.Output(os.Stderr)
-	fmt.Fprint(output, "\rsecuring channel...")
+	if !c.Options.Events {
+		output, _ := termui.Output(os.Stderr)
+		fmt.Fprint(output, "\rsecuring channel...")
+	}
 	err = c.transferWithReconnect(func(attempt int) error {
 		if attempt == 0 {
 			return nil
@@ -1881,8 +1920,8 @@ func (c *Client) Receive() (err error) {
 		return c.receiverReconnectRelayAttempt(attempt)
 	})
 	if err == nil {
-		if c.numberOfTransferredFiles+len(c.EmptyFoldersToTransfer) == 0 {
-			output, _ = termui.Output(os.Stderr)
+		if c.numberOfTransferredFiles+len(c.EmptyFoldersToTransfer) == 0 && !c.Options.Events {
+			output, _ := termui.Output(os.Stderr)
 			fmt.Fprint(output, "\rNo files transferred.\n")
 		}
 	} else if !isTransferDisconnectError(err) {
@@ -2007,7 +2046,9 @@ func (c *Client) transfer() (err error) {
 		if err = os.Remove(pathToFile); err != nil {
 			log.Warnf("error removing %s: %v", pathToFile, err)
 		}
-		fmt.Fprint(os.Stderr, "\n")
+		if !c.Options.Events {
+			fmt.Fprint(os.Stderr, "\n")
+		}
 	}
 	if err != nil && strings.Contains(err.Error(), "pake not successful") {
 		log.Debugf("pake error: %s", err.Error())
@@ -2181,6 +2222,7 @@ func (c *Client) processMessageFileInfo(m message.Message) (done bool, err error
 
 	// if no files are to be transferred, then we can end the file transfer process
 	if c.FilesToTransfer == nil {
+		c.emitComplete()
 		c.SuccessfulTransfer = true
 		c.Step3RecipientRequestFile = true
 		c.Step4FileTransferred = true
@@ -2443,6 +2485,7 @@ func (c *Client) processMessage(payload []byte, attempt *transferAttemptState) (
 			Type: message.TypeFinished,
 		})
 		done = true
+		c.emitComplete()
 		c.SuccessfulTransfer = true
 		return
 	case message.TypePAKE:
@@ -2652,6 +2695,7 @@ func (c *Client) recipientGetFileReady(finished bool) (err error) {
 		if err != nil {
 			return
 		}
+		c.emitComplete()
 		c.SuccessfulTransfer = true
 		c.FilesHasFinished[c.FilesToTransferCurrentNum] = struct{}{}
 		return
@@ -2803,7 +2847,7 @@ func (c *Client) updateIfRecipientHasFileInfo() (err error) {
 		var fileHash []byte
 		if errRecipientFile == nil && recipientFileInfo.Size() == fileInfo.Size {
 			// the file exists, but is same size, so hash it
-			fileHash, errHash = utils.HashFile(path.Join(fileInfo.FolderRemote, fileInfo.Name), c.Options.HashAlgorithm, !c.Options.SendingText)
+			fileHash, errHash = utils.HashFile(path.Join(fileInfo.FolderRemote, fileInfo.Name), c.Options.HashAlgorithm, !c.Options.SendingText && !c.Options.Events)
 		}
 		if fileInfo.Size == 0 || fileInfo.Symlink != "" {
 			err = c.createEmptyFileAndFinish(fileInfo, i)
@@ -2901,7 +2945,7 @@ func (c *Client) fmtPrintUpdate() {
 	if c.TotalNumberOfContents > 1 {
 		output, colorEnabled := termui.Output(os.Stderr)
 		fmt.Fprintln(output, termui.Success(fmt.Sprintf(" %d/%d", c.finishedNum, c.TotalNumberOfContents), colorEnabled))
-	} else {
+	} else if !c.Options.Events {
 		fmt.Fprintf(os.Stderr, "\n")
 	}
 }
@@ -2984,6 +3028,7 @@ func (c *Client) setBar() {
 		log.Debug(bytesDone)
 		if bytesDone > 0 {
 			c.bar.Add64(bytesDone)
+			c.emitProgress(bytesDone)
 		}
 	}
 }
@@ -3065,6 +3110,7 @@ func (c *Client) receiveData(i int, dataConn *comm.Comm, attempt *transferAttemp
 			return
 		}
 		c.bar.Add(len(data[8:]))
+		c.emitProgress(int64(len(data[8:])))
 		c.TotalSent += int64(len(data[8:]))
 		c.TotalChunksTransferred++
 		// log.Debug(len(c.CurrentFileChunks), c.TotalChunksTransferred, c.TotalSent, c.FilesToTransfer[c.FilesToTransferCurrentNum].Size)
@@ -3173,6 +3219,7 @@ func (c *Client) sendData(i int, dataConn *comm.Comm, fread *os.File, attempt *t
 						return
 					}
 					c.bar.Add(n)
+					c.emitProgress(int64(n))
 					c.TotalSent += int64(n)
 					// time.Sleep(100 * time.Millisecond)
 				}

--- a/src/croc/events_e2e_test.go
+++ b/src/croc/events_e2e_test.go
@@ -1,0 +1,147 @@
+package croc
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/schollz/croc/v11/src/events"
+	log "github.com/schollz/logger"
+)
+
+// TestJSONEventsE2E runs a full send/receive with JSON events enabled and
+// verifies the stream contains version-agnostic phase, progress and
+// completion events.
+func TestJSONEventsE2E(t *testing.T) {
+	log.SetLevel("trace")
+	var wg sync.WaitGroup
+
+	os.Remove("touched")
+	os.Create("touched")
+	defer os.Remove("touched")
+
+	sender, err := New(Options{
+		IsSender:      true,
+		SharedSecret:  "8123-json-events",
+		Debug:         true,
+		RelayAddress:  "127.0.0.1:8181",
+		RelayPorts:    []string{"8181", "8182"},
+		RelayPassword: "pass123",
+		Stdout:        true,
+		NoPrompt:      true,
+		DisableLocal:  false,
+		Curve:         "ed25519",
+		Overwrite:     true,
+		Events:        true,
+	})
+	if err != nil {
+		t.Fatalf("sender: %v", err)
+	}
+	receiver, err := New(Options{
+		IsSender:      false,
+		SharedSecret:  "8123-json-events",
+		Debug:         true,
+		RelayAddress:  "127.0.0.1:8181",
+		RelayPassword: "pass123",
+		Stdout:        true,
+		NoPrompt:      true,
+		DisableLocal:  false,
+		Curve:         "ed25519",
+		Overwrite:     true,
+		Events:        true,
+	})
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+
+	// Capture the event stream instead of stderr.
+	var eventsBuf bytes.Buffer
+	events.Enable(&eventsBuf)
+	defer events.Enable(nil)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		filesInfo, emptyFolders, totalNumberFolders, errGet := GetFilesInfo([]string{"../../LICENSE", "touched"}, false, false, []string{})
+		if errGet != nil {
+			t.Errorf("failed to get minimal info: %v", errGet)
+			return
+		}
+		if err := sender.Send(filesInfo, emptyFolders, totalNumberFolders); err != nil {
+			t.Errorf("send failed: %v", err)
+		}
+	}()
+	time.Sleep(100 * time.Millisecond)
+	go func() {
+		defer wg.Done()
+		if err := receiver.Receive(); err != nil {
+			t.Errorf("receive failed: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimSpace(eventsBuf.String()), "\n")
+	if len(lines) < 4 {
+		t.Fatalf("expected several event lines, got %d: %q", len(lines), eventsBuf.String())
+	}
+
+	var phases []string
+	var progress events.ProgressEvent
+	sawProgress := false
+	var complete events.CompleteEvent
+	sawComplete := false
+	for _, line := range lines {
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			t.Fatalf("invalid event line %q: %v", line, err)
+		}
+		switch raw["type"] {
+		case "phase":
+			phase, _ := raw["phase"].(string)
+			phases = append(phases, phase)
+		case "progress":
+			if err := json.Unmarshal([]byte(line), &progress); err != nil {
+				t.Fatalf("progress event %q: %v", line, err)
+			}
+			sawProgress = true
+		case "complete":
+			if err := json.Unmarshal([]byte(line), &complete); err != nil {
+				t.Fatalf("complete event %q: %v", line, err)
+			}
+			sawComplete = true
+		}
+	}
+
+	if !sawComplete || len(complete.Files) != 2 {
+		t.Errorf("expected complete event with 2 files, got %+v (saw=%v)", complete, sawComplete)
+	}
+
+	// At least one progress event for a non-empty file, fully transferred.
+	if !sawProgress {
+		t.Error("expected at least one progress event")
+	} else if progress.BytesTotal <= 0 {
+		t.Errorf("progress bytesTotal = %d, want > 0", progress.BytesTotal)
+	} else if progress.BytesTransferred > progress.BytesTotal {
+		t.Errorf("progress bytesTransferred %d > bytesTotal %d", progress.BytesTransferred, progress.BytesTotal)
+	} else if progress.Percent < 0 || progress.Percent > 100 {
+		t.Errorf("progress percent = %v, want in [0,100]", progress.Percent)
+	}
+
+	// Both sides emit connecting and transferring; the sender emits hashing.
+	for _, want := range []string{"connecting", "transferring"} {
+		found := false
+		for _, phase := range phases {
+			if phase == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected phase %q in events, got %v", want, phases)
+		}
+	}
+}

--- a/src/croc/events_e2e_test.go
+++ b/src/croc/events_e2e_test.go
@@ -116,8 +116,11 @@ func TestJSONEventsE2E(t *testing.T) {
 		}
 	}
 
-	if !sawComplete || len(complete.Files) != 2 {
-		t.Errorf("expected complete event with 2 files, got %+v (saw=%v)", complete, sawComplete)
+	if !sawComplete {
+		t.Error("expected complete event")
+	}
+	if len(complete.Files) != 2 {
+		t.Errorf("expected complete event with 2 files, got %+v", complete.Files)
 	}
 
 	// At least one progress event for a non-empty file, fully transferred.

--- a/src/croc/events_hooks.go
+++ b/src/croc/events_hooks.go
@@ -1,0 +1,93 @@
+package croc
+
+import (
+	"time"
+
+	"github.com/schollz/croc/v11/src/events"
+)
+
+// progressEventInterval is the minimum time between progress events.
+const progressEventInterval = 100 * time.Millisecond
+
+// emitPhase forwards a phase transition to the JSON event stream.
+func (c *Client) emitPhase(phase, message string) {
+	events.Phase(phase, message)
+}
+
+// emitProgress forwards per-file transfer progress to the JSON event
+// stream, throttled to progressEventInterval. It is a no-op when events
+// are disabled.
+func (c *Client) emitProgress(added int64) {
+	if !events.Enabled() {
+		return
+	}
+	c.progMu.Lock()
+	defer c.progMu.Unlock()
+
+	if c.FilesToTransferCurrentNum != c.progFileNum || !c.progEmitStarted {
+		c.progFileNum = c.FilesToTransferCurrentNum
+		c.progBytes = 0
+		c.progLastBytes = 0
+		c.progLastEmit = time.Time{}
+		c.progEmitStarted = true
+	}
+
+	c.progBytes += added
+	if c.FilesToTransferCurrentNum >= len(c.FilesToTransfer) {
+		return
+	}
+	fileInfo := c.FilesToTransfer[c.FilesToTransferCurrentNum]
+	if c.progBytes > fileInfo.Size {
+		c.progBytes = fileInfo.Size
+	}
+
+	now := time.Now()
+	if !c.progLastEmit.IsZero() && now.Sub(c.progLastEmit) < progressEventInterval && c.progBytes < fileInfo.Size {
+		return
+	}
+
+	var speedBps int64
+	if !c.progLastEmit.IsZero() && now.After(c.progLastEmit) {
+		elapsed := now.Sub(c.progLastEmit).Seconds()
+		if elapsed > 0 {
+			speedBps = int64(float64(c.progBytes-c.progLastBytes) / elapsed)
+		}
+	}
+
+	var percent float64
+	if fileInfo.Size > 0 {
+		percent = float64(c.progBytes) / float64(fileInfo.Size) * 100
+	}
+
+	events.Progress(events.ProgressEvent{
+		File:             fileInfo.Name,
+		BytesTransferred: c.progBytes,
+		BytesTotal:       fileInfo.Size,
+		Percent:          percent,
+		SpeedBps:         speedBps,
+	})
+	c.progLastEmit = now
+	c.progLastBytes = c.progBytes
+}
+
+// completedFiles builds the file list for the completion event.
+func (c *Client) completedFiles() []events.CompleteFile {
+	files := make([]events.CompleteFile, 0, len(c.FilesToTransfer))
+	for _, fileInfo := range c.FilesToTransfer {
+		files = append(files, events.CompleteFile{
+			Name:  fileInfo.Name,
+			Bytes: fileInfo.Size,
+		})
+	}
+	return files
+}
+
+// emitComplete marks the transfer as finished in the JSON event stream.
+// It is a no-op once the transfer has already completed.
+func (c *Client) emitComplete() {
+	if c.transferComplete.Swap(true) {
+		return
+	}
+	events.Complete(c.completedFiles())
+	events.Phase("complete", "transfer complete")
+}

--- a/src/croc/terminal_display.go
+++ b/src/croc/terminal_display.go
@@ -24,7 +24,7 @@ func (c *Client) newProgressBar(max int64, description string, throttle time.Dur
 		progressbar.OptionShowBytes(true),
 		progressbar.OptionShowCount(),
 		progressbar.OptionSetWriter(progressBarWriter(output, colorEnabled)),
-		progressbar.OptionSetVisibility(!c.Options.SendingText),
+		progressbar.OptionSetVisibility(!c.Options.SendingText && !c.Options.Events),
 		progressbar.OptionEnableColorCodes(colorEnabled),
 		progressbar.OptionSetTheme(progressBarTheme(colorEnabled)),
 	}

--- a/src/events/events.go
+++ b/src/events/events.go
@@ -1,0 +1,180 @@
+// Package events emits newline-delimited JSON events for machine
+// consumption (--json). The human-oriented output is left untouched.
+//
+// Event emission is off until Enable is called, so existing callers
+// and tests that never opt in are unaffected.
+package events
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"sync"
+)
+
+// Event types.
+const (
+	TypeVersion  = "version"
+	TypeCode     = "code"
+	TypePhase    = "phase"
+	TypeProgress = "progress"
+	TypeComplete = "complete"
+	TypeStore    = "store"
+	TypeError    = "error"
+)
+
+// VersionEvent is emitted once at startup.
+type VersionEvent struct {
+	Type    string `json:"type"`
+	Version string `json:"version"`
+}
+
+// CodeEvent reports the code phrase the recipient needs to join.
+type CodeEvent struct {
+	Type string `json:"type"`
+	Code string `json:"code"`
+}
+
+// PhaseEvent reports a transfer phase transition.
+type PhaseEvent struct {
+	Type    string `json:"type"`
+	Phase   string `json:"phase"`
+	Message string `json:"message,omitempty"`
+}
+
+// ProgressEvent reports transfer progress for the current file.
+type ProgressEvent struct {
+	Type             string  `json:"type"`
+	File             string  `json:"file"`
+	BytesTransferred int64   `json:"bytesTransferred"`
+	BytesTotal       int64   `json:"bytesTotal"`
+	Percent          float64 `json:"percent"`
+	SpeedBps         int64   `json:"speedBps"`
+}
+
+// CompleteFile describes a single transferred file in a CompleteEvent.
+type CompleteFile struct {
+	Name  string `json:"name"`
+	Bytes int64  `json:"bytes"`
+}
+
+// CompleteEvent is emitted when the transfer finishes successfully.
+type CompleteEvent struct {
+	Type  string         `json:"type"`
+	Files []CompleteFile `json:"files"`
+}
+
+// StoreEvent is emitted for stored transfers with the share details.
+type StoreEvent struct {
+	Type      string `json:"type"`
+	URL       string `json:"url,omitempty"`
+	Token     string `json:"token,omitempty"`
+	ExpiresAt string `json:"expiresAt,omitempty"`
+	RevokeID  string `json:"revokeId,omitempty"`
+}
+
+// ErrorEvent is emitted when the command fails.
+type ErrorEvent struct {
+	Type    string `json:"type"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+var (
+	mu     sync.Mutex
+	active *json.Encoder
+)
+
+// Enable turns on event emission, writing newline-delimited JSON to w.
+func Enable(w io.Writer) {
+	mu.Lock()
+	defer mu.Unlock()
+	if w == nil {
+		active = nil
+		return
+	}
+	active = json.NewEncoder(w)
+}
+
+// Enabled reports whether event emission is on.
+func Enabled() bool {
+	mu.Lock()
+	defer mu.Unlock()
+	return active != nil
+}
+
+// Emit writes a single event. It is a no-op unless Enable was called.
+func Emit(v any) {
+	mu.Lock()
+	defer mu.Unlock()
+	if active != nil {
+		_ = active.Encode(v)
+	}
+}
+
+// Version emits the version event.
+func Version(version string) {
+	Emit(VersionEvent{Type: TypeVersion, Version: version})
+}
+
+// Code emits the code phrase event.
+func Code(code string) {
+	Emit(CodeEvent{Type: TypeCode, Code: code})
+}
+
+// Phase emits a phase transition event.
+func Phase(phase, message string) {
+	Emit(PhaseEvent{Type: TypePhase, Phase: phase, Message: message})
+}
+
+// Progress emits a transfer progress event.
+func Progress(progress ProgressEvent) {
+	progress.Type = TypeProgress
+	Emit(progress)
+}
+
+// Complete emits the transfer completion event.
+func Complete(files []CompleteFile) {
+	Emit(CompleteEvent{Type: TypeComplete, Files: files})
+}
+
+// Store emits a stored-transfer details event.
+func Store(url, token, expiresAt, revokeID string) {
+	Emit(StoreEvent{
+		Type:      TypeStore,
+		URL:       url,
+		Token:     token,
+		ExpiresAt: expiresAt,
+		RevokeID:  revokeID,
+	})
+}
+
+// Error emits an error event for err, mapping the message to a stable code.
+func Error(err error) {
+	code, hint := classify(err)
+	Emit(ErrorEvent{Type: TypeError, Code: code, Message: err.Error(), Hint: hint})
+}
+
+func classify(err error) (code, hint string) {
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "could not connect"),
+		strings.Contains(msg, "connection refused"),
+		strings.Contains(msg, "relay unreachable"):
+		return "relay_unreachable", "check --relay and your proxy settings"
+	case strings.Contains(msg, "bad password"),
+		strings.Contains(msg, "message authentication failed"),
+		strings.Contains(msg, "passphrase"):
+		return "auth_failed", "make sure both sides use the same code phrase and relay password"
+	case strings.Contains(msg, "timed out"),
+		strings.Contains(msg, "timeout"),
+		strings.Contains(msg, "deadline exceeded"):
+		return "timed_out", "check your network connection and try again"
+	case strings.Contains(msg, "could not secure channel"),
+		strings.Contains(msg, "handshake"):
+		return "handshake_failed", "the code phrase may be wrong, or the relay may be unreachable"
+	default:
+		return "failed", ""
+	}
+}

--- a/src/events/events_test.go
+++ b/src/events/events_test.go
@@ -1,0 +1,110 @@
+package events
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDisabledEmitIsNoOp(t *testing.T) {
+	var buf bytes.Buffer
+	Enable(&buf)
+	Disable := func() {
+		mu.Lock()
+		active = nil
+		mu.Unlock()
+	}
+	Disable()
+	Emit(VersionEvent{Type: TypeVersion, Version: "1.2.3"})
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output while disabled, got %q", buf.String())
+	}
+}
+
+func TestEventsEmitValidLines(t *testing.T) {
+	var buf bytes.Buffer
+	Enable(&buf)
+	Version("10.7.0")
+	Code("alpha-forest-42")
+	Phase("connecting", "connecting to relay")
+	Progress(ProgressEvent{
+		File:             "file.zip",
+		BytesTransferred: 1048576,
+		BytesTotal:       10485760,
+		Percent:          10,
+		SpeedBps:         524288,
+	})
+	Complete([]CompleteFile{{Name: "file.zip", Bytes: 10485760}})
+	Store("https://getcroc.com/s/a", "croc-store-v1-token", "2026-07-30T03:00:00Z", "abc123")
+	Error(errors.New("could not connect to relay: refused"))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 7 {
+		t.Fatalf("expected 7 event lines, got %d: %q", len(lines), buf.String())
+	}
+
+	typeField := func(line string) string {
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		typ, _ := raw["type"].(string)
+		return typ
+	}
+	wantTypes := []string{TypeVersion, TypeCode, TypePhase, TypeProgress, TypeComplete, TypeStore, TypeError}
+	for i, line := range lines {
+		if typ := typeField(line); typ != wantTypes[i] {
+			t.Errorf("line %d: type = %q, want %q", i, typ, wantTypes[i])
+		}
+	}
+
+	var progress ProgressEvent
+	if err := json.Unmarshal([]byte(lines[3]), &progress); err != nil {
+		t.Fatalf("progress unmarshal: %v", err)
+	}
+	if progress.BytesTransferred != 1048576 || progress.BytesTotal != 10485760 || progress.SpeedBps != 524288 {
+		t.Errorf("progress fields wrong: %+v", progress)
+	}
+	if progress.Percent != 10 {
+		t.Errorf("percent = %v, want 10", progress.Percent)
+	}
+
+	var store StoreEvent
+	if err := json.Unmarshal([]byte(lines[5]), &store); err != nil {
+		t.Fatalf("store unmarshal: %v", err)
+	}
+	if store.URL != "https://getcroc.com/s/a" || store.Token != "croc-store-v1-token" || store.ExpiresAt != "2026-07-30T03:00:00Z" || store.RevokeID != "abc123" {
+		t.Errorf("store fields wrong: %+v", store)
+	}
+}
+
+func TestErrorClassification(t *testing.T) {
+	cases := []struct {
+		message string
+		want    string
+	}{
+		{"could not connect to 127.0.0.1:9009: connection refused", "relay_unreachable"},
+		{"bad password", "auth_failed"},
+		{"message authentication failed", "auth_failed"},
+		{"context deadline exceeded", "timed_out"},
+		{"could not secure channel", "handshake_failed"},
+		{"something unexpected", "failed"},
+	}
+	for _, c := range cases {
+		var buf bytes.Buffer
+		Enable(&buf)
+		Error(errors.New(c.message))
+		var errEvent ErrorEvent
+		if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &errEvent); err != nil {
+			t.Fatalf("unmarshal %q: %v", buf.String(), err)
+		}
+		if errEvent.Code != c.want {
+			t.Errorf("message %q: code = %q, want %q", c.message, errEvent.Code, c.want)
+		}
+		if errEvent.Message != c.message {
+			t.Errorf("message field = %q, want %q", errEvent.Message, c.message)
+		}
+	}
+}

--- a/src/termui/termui.go
+++ b/src/termui/termui.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync/atomic"
 
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
@@ -22,9 +23,21 @@ const (
 
 var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
+var humanOutputMuted atomic.Bool
+
+// MuteHumanOutput discards all terminal output. It is used by --json mode,
+// where machine-readable events replace the human-oriented UI.
+func MuteHumanOutput(muted bool) {
+	humanOutputMuted.Store(muted)
+}
+
 // Output returns a Windows-aware writer and whether styling should be used.
 func Output(file *os.File) (io.Writer, bool) {
 	if file == nil {
+		return io.Discard, false
+	}
+
+	if humanOutputMuted.Load() {
 		return io.Discard, false
 	}
 


### PR DESCRIPTION
## What

Adds a global `--json` flag that makes croc emit newline-delimited JSON events on stderr instead of the human-oriented UI. The default output is completely unchanged.

```
$ croc --json send bigfile.bin  2> events.ndjson
{"type":"version","version":"11.0.3"}
{"type":"code","code":"secret-phrase"}
{"type":"phase","phase":"hashing","message":"hashing files"}
{"type":"phase","phase":"connecting","message":"connecting to relay"}
{"type":"phase","phase":"transferring","message":"transferring files"}
{"type":"progress","file":"bigfile.bin","bytesTransferred":...,"bytesTotal":...,"percent":...,"speedBps":...}
{"type":"complete","files":[{"name":"bigfile.bin","bytes":...}]}
{"type":"phase","phase":"complete","message":"transfer complete"}
```

## Event types

| type | sender | receiver | payload |
|---|---|---|---|
| `version` | yes | yes | croc version |
| `code` | yes | - | code phrase the recipient needs |
| `phase` | yes | yes | hashing / connecting / transferring / complete |
| `progress` | yes | yes | file, bytesTransferred, bytesTotal, percent, speedBps (throttled to 100 ms) |
| `complete` | yes | yes | list of transferred files with sizes |
| `store` | stored-send only | - | browser URL, token, expiry, share ID |
| `error` | both | both | error message with stable code (on non-zero exit) |

## Implementation

- New `src/events` package: off by default, `events.Enable(os.Stderr)` opts in. All existing code paths and tests are unaffected.
- `--json` suppresses progress bars, status lines, the QR code, clipboard copy, and hashing bars so the stream stays machine-parseable (verified end-to-end).
- `complete` and `transferring` are emitted exactly once per process.
- Wrappers can read the code phrase before any recipient connects, and exit with a non-zero status on error.

## Testing

- `src/events`: event encoding tests.
- `src/croc`: end-to-end tests covering direct transfers (sender + receiver event sequences) and stored transfers (`store` + `complete` events).
- Live relay smoke test: sender/receiver streams parse as pure NDJSON with zero human noise, transfer byte-identical.

Closes #1201