### PR TITLE
docs(README.md): fix stale Go version requirement in README (Go 1.25+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ You can also just paste it in the terminal for current session. On first run Doc
 
 ### Build from Source
 
-If you prefer, you can [install Go](https://go.dev/dl/) and build from source (requires Go 1.22+):
+If you prefer, you can [install Go](https://go.dev/dl/) and build from source (requires Go 1.25+):
 
 ```bash
 go install github.com/schollz/croc/v10@latest


### PR DESCRIPTION


The README still said Go 1.22+, but go.mod now requires Go 1.25.
Go 1.21+ will automatically download the required toolchain with `GOTOOLCHAIN=auto`,
so this is just a documentation fix.