### PR TITLE
Add a Debian install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ apk add bash coreutils
 wget -qO- https://getcroc.com | bash
 ```
 
+### On Debian
+
+Install from the pkg.haus APT archive:
+
+```bash
+# Add the repository (see https://pkg.haus for setup instructions)
+sudo apt install croc
+```
+
 ### On Arch Linux
 
 Install with `pacman`:


### PR DESCRIPTION
[pkg.haus](https://pkg.haus) is a signed APT archive carrying croc for Debian stable, testing and unstable (amd64/arm64), built from source at upstream release tags. This adds an 'On Debian' section in alphabetical position.