### PR TITLE
chore: go fix

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -81,7 +81,7 @@ type App struct {
 	// is used as the default behavior.
 	ExitErrHandler ExitErrHandlerFunc
 	// Other custom info
-	Metadata map[string]interface{}
+	Metadata map[string]any
 	// Carries a function which returns app specific info.
 	ExtraInfo func() map[string]string
 	// CustomAppHelpTemplate the text template for app help topic.
@@ -199,7 +199,7 @@ func (a *App) Setup() {
 	sort.Sort(a.categories.(*commandCategories))
 
 	if a.Metadata == nil {
-		a.Metadata = make(map[string]interface{})
+		a.Metadata = make(map[string]any)
 	}
 }
 
@@ -518,7 +518,7 @@ func (a *Author) String() string {
 // HandleAction attempts to figure out which Action signature was used.  If
 // it's an ActionFunc or a func with the legacy signature for Action, the func
 // is run!
-func HandleAction(action interface{}, context *Context) (err error) {
+func HandleAction(action any, context *Context) (err error) {
 	switch a := action.(type) {
 	case ActionFunc:
 		return a(context)

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"flag"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -206,12 +207,7 @@ func (c *Command) Names() []string {
 
 // HasName returns true if Command.Name matches given name
 func (c *Command) HasName(name string) bool {
-	for _, n := range c.Names() {
-		if n == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(c.Names(), name)
 }
 
 func (c *Command) startApp(ctx *Context) error {
@@ -290,11 +286,5 @@ func (c *Command) appendFlag(fl Flag) {
 }
 
 func hasCommand(commands []*Command, command *Command) bool {
-	for _, existing := range commands {
-		if command == existing {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(commands, command)
 }

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -107,7 +108,7 @@ func (c *Context) Lineage() []*Context {
 }
 
 // Value returns the value of the flag corresponding to `name`
-func (c *Context) Value(name string) interface{} {
+func (c *Context) Value(name string) any {
 	return c.flagSet.Lookup(name).Value.(flag.Getter).Get()
 }
 
@@ -129,20 +130,16 @@ func lookupFlag(name string, ctx *Context) Flag {
 		}
 
 		for _, f := range c.Command.Flags {
-			for _, n := range f.Names() {
-				if n == name {
-					return f
-				}
+			if slices.Contains(f.Names(), name) {
+				return f
 			}
 		}
 	}
 
 	if ctx.App != nil {
 		for _, f := range ctx.App.Flags {
-			for _, n := range f.Names() {
-				if n == name {
-					return f
-				}
+			if slices.Contains(f.Names(), name) {
+				return f
 			}
 		}
 	}

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -61,13 +61,13 @@ type ExitCoder interface {
 
 type exitError struct {
 	exitCode int
-	message  interface{}
+	message  any
 }
 
 // NewExitError calls Exit to create a new ExitCoder.
 //
 // Deprecated: This function is a duplicate of Exit and will eventually be removed.
-func NewExitError(message interface{}, exitCode int) ExitCoder {
+func NewExitError(message any, exitCode int) ExitCoder {
 	return Exit(message, exitCode)
 }
 
@@ -78,7 +78,7 @@ func NewExitError(message interface{}, exitCode int) ExitCoder {
 // having to call os.Exit manually. During testing, this behavior can be avoided
 // by overiding the ExitErrHandler function on an App or the package-global
 // OsExiter function.
-func Exit(message interface{}, exitCode int) ExitCoder {
+func Exit(message any, exitCode int) ExitCoder {
 	return &exitError{
 		message:  message,
 		exitCode: exitCode,

--- a/internal/cli/flag.go
+++ b/internal/cli/flag.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -164,21 +166,21 @@ func unquoteUsage(usage string) (string, string) {
 }
 
 func prefixedNames(names []string, placeholder string) string {
-	var prefixed string
+	var prefixed strings.Builder
 	for i, name := range names {
 		if name == "" {
 			continue
 		}
 
-		prefixed += prefixFor(name) + name
+		prefixed.WriteString(prefixFor(name) + name)
 		if placeholder != "" {
-			prefixed += " " + placeholder
+			prefixed.WriteString(" " + placeholder)
 		}
 		if i < len(names)-1 {
-			prefixed += ", "
+			prefixed.WriteString(", ")
 		}
 	}
-	return prefixed
+	return prefixed.String()
 }
 
 func withEnvHint(envVars []string, str string) string {
@@ -236,7 +238,7 @@ func withFileHint(filePath, str string) string {
 
 func flagValue(f Flag) reflect.Value {
 	fv := reflect.ValueOf(f)
-	for fv.Kind() == reflect.Ptr {
+	for fv.Kind() == reflect.Pointer {
 		fv = reflect.Indirect(fv)
 	}
 	return fv
@@ -318,13 +320,7 @@ func stringifySliceFlag(usage string, names, defaultVals []string) string {
 }
 
 func hasFlag(flags []Flag, fl Flag) bool {
-	for _, existing := range flags {
-		if fl == existing {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(flags, fl)
 }
 
 func flagFromEnvOrFile(envVars []string, filePath string) (val string, ok bool) {
@@ -334,8 +330,8 @@ func flagFromEnvOrFile(envVars []string, filePath string) (val string, ok bool) 
 			return val, true
 		}
 	}
-	for _, fileVar := range strings.Split(filePath, ",") {
-		if data, err := ioutil.ReadFile(fileVar); err == nil {
+	for fileVar := range strings.SplitSeq(filePath, ",") {
+		if data, err := os.ReadFile(fileVar); err == nil {
 			return string(data), true
 		}
 	}

--- a/internal/cli/flag_string_slice.go
+++ b/internal/cli/flag_string_slice.go
@@ -54,7 +54,7 @@ func (s *StringSlice) Value() []string {
 }
 
 // Get returns the slice of strings set by this flag
-func (s *StringSlice) Get() interface{} {
+func (s *StringSlice) Get() any {
 	return *s
 }
 
@@ -130,7 +130,7 @@ func (f *StringSliceFlag) Apply(set *flag.FlagSet) error {
 			destination = f.Destination
 		}
 
-		for _, s := range strings.Split(val, ",") {
+		for s := range strings.SplitSeq(val, ",") {
 			if err := destination.Set(strings.TrimSpace(s)); err != nil {
 				return fmt.Errorf("could not parse %q as string value for flag %s: %s", val, f.Name, err)
 			}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"unicode/utf8"
 )
@@ -40,10 +41,10 @@ var helpSubcommand = &Command{
 }
 
 // Prints help for the App or Command
-type helpPrinter func(w io.Writer, templ string, data interface{})
+type helpPrinter func(w io.Writer, templ string, data any)
 
 // Prints help for the App or Command with custom template function.
-type helpPrinterCustom func(w io.Writer, templ string, data interface{}, customFunc map[string]interface{})
+type helpPrinterCustom func(w io.Writer, templ string, data any, customFunc map[string]any)
 
 // HelpPrinter is a function that writes the help output. If not set explicitly,
 // this calls HelpPrinterCustom using only the default template functions.
@@ -80,8 +81,8 @@ func ShowAppHelp(c *Context) error {
 		return nil
 	}
 
-	customAppData := func() map[string]interface{} {
-		return map[string]interface{}{
+	customAppData := func() map[string]any {
+		return map[string]any{
 			"ExtraInfo": c.App.ExtraInfo,
 		}
 	}
@@ -113,17 +114,12 @@ func printCommandSuggestions(commands []*Command, writer io.Writer) {
 }
 
 func cliArgContains(flagName string) bool {
-	for _, name := range strings.Split(flagName, ",") {
+	for name := range strings.SplitSeq(flagName, ",") {
 		name = strings.TrimSpace(name)
-		count := utf8.RuneCountInString(name)
-		if count > 2 {
-			count = 2
-		}
+		count := min(utf8.RuneCountInString(name), 2)
 		flag := fmt.Sprintf("%s%s", strings.Repeat("-", count), name)
-		for _, a := range os.Args {
-			if a == flag {
-				return true
-			}
+		if slices.Contains(os.Args, flag) {
+			return true
 		}
 	}
 	return false
@@ -139,10 +135,9 @@ func printFlagSuggestions(lastArg string, flags []Flag, writer io.Writer) {
 		for _, name := range flag.Names() {
 			name = strings.TrimSpace(name)
 			// this will get total count utf8 letters in flag name
-			count := utf8.RuneCountInString(name)
-			if count > 2 {
-				count = 2 // resuse this count to generate single - or -- in flag completion
-			}
+			count := min(utf8.RuneCountInString(name),
+				// resuse this count to generate single - or -- in flag completion
+				2)
 			// if flag name has more than one utf8 letter and last argument in cli has -- prefix then
 			// skip flag completion for short flags example -v or -x
 			if strings.HasPrefix(lastArg, "--") && count == 1 {
@@ -262,7 +257,7 @@ func ShowCommandCompletions(ctx *Context, command string) {
 // a direct renderer keeps the same output while allowing method dead-code
 // elimination. templ is still used to distinguish app and subcommand layouts;
 // custom templates and functions are intentionally unsupported by this fork.
-func printHelpCustom(out io.Writer, templ string, data interface{}, customFuncs map[string]interface{}) {
+func printHelpCustom(out io.Writer, templ string, data any, customFuncs map[string]any) {
 	switch value := data.(type) {
 	case *App:
 		if templ == SubcommandHelpTemplate {
@@ -438,7 +433,7 @@ func renderHelpRows(w io.Writer, prefix string, rows []helpRow) {
 	}
 }
 
-func printHelp(out io.Writer, templ string, data interface{}) {
+func printHelp(out io.Writer, templ string, data any) {
 	HelpPrinterCustom(out, templ, data, nil)
 }
 

--- a/internal/cli/sort.go
+++ b/internal/cli/sort.go
@@ -7,12 +7,9 @@ func lexicographicLess(i, j string) bool {
 	iRunes := []rune(i)
 	jRunes := []rune(j)
 
-	lenShared := len(iRunes)
-	if lenShared > len(jRunes) {
-		lenShared = len(jRunes)
-	}
+	lenShared := min(len(iRunes), len(jRunes))
 
-	for index := 0; index < lenShared; index++ {
+	for index := range lenShared {
 		ir := iRunes[index]
 		jr := jRunes[index]
 

--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -498,7 +498,7 @@ func applyRememberedSendOptions(c *cli.Context, options *croc.Options, remembere
 // same as "9009,9010" instead of producing invalid port strings like " 9010".
 func parseRelayPorts(portsFlag string) []string {
 	var ports []string
-	for _, p := range strings.Split(portsFlag, ",") {
+	for p := range strings.SplitSeq(portsFlag, ",") {
 		if p = strings.TrimSpace(p); p != "" {
 			ports = append(ports, p)
 		}
@@ -526,14 +526,14 @@ func send(c *cli.Context) (err error) {
 		transfersParam = 4
 	}
 	excludeStrings := []string{}
-	for _, v := range strings.Split(c.String("exclude"), ",") {
+	for v := range strings.SplitSeq(c.String("exclude"), ",") {
 		v = strings.ToLower(strings.TrimSpace(v))
 		if v != "" {
 			excludeStrings = append(excludeStrings, v)
 		}
 	}
 	excludeFiles := []string{}
-	for _, v := range strings.Split(c.String("exclude-file"), ",") {
+	for v := range strings.SplitSeq(c.String("exclude-file"), ",") {
 		v = utils.NormalizeRelativePath(strings.TrimSpace(v))
 		if v != "" && v != "." {
 			excludeFiles = append(excludeFiles, v)

--- a/src/codephrase/codephrase.go
+++ b/src/codephrase/codephrase.go
@@ -240,8 +240,8 @@ func isLowercaseWord(word string) bool {
 }
 
 func isLowercaseListWord(word string) bool {
-	parts := strings.Split(word, "-")
-	for _, part := range parts {
+	parts := strings.SplitSeq(word, "-")
+	for part := range parts {
 		if !isLowercaseWord(part) {
 			return false
 		}

--- a/src/croc/croc.go
+++ b/src/croc/croc.go
@@ -18,6 +18,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -234,7 +235,7 @@ type FileInfo struct {
 	FolderSource string      `json:"fs,omitempty"`
 	Hash         []byte      `json:"h,omitempty"`
 	Size         int64       `json:"s,omitempty"`
-	ModTime      time.Time   `json:"m,omitempty"`
+	ModTime      time.Time   `json:"m,omitzero"`
 	IsCompressed bool        `json:"c"`
 	IsEncrypted  bool        `json:"e,omitempty"`
 	Symlink      string      `json:"sy,omitempty"`
@@ -275,12 +276,7 @@ const perFileCompressionFeature = "per-file-compression-v1"
 var ErrRelayConnection = errors.New("relay connection failed")
 
 func supportsFeature(features []string, wanted string) bool {
-	for _, feature := range features {
-		if feature == wanted {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(features, wanted)
 }
 
 // New establishes a new connection for transferring files between two instances.
@@ -503,10 +499,8 @@ func (c *Client) rememberReconnectRelayAddress(address string) {
 	}
 	c.reconnectRelayMu.Lock()
 	defer c.reconnectRelayMu.Unlock()
-	for _, existing := range c.reconnectRelayAddresses {
-		if existing == address {
-			return
-		}
+	if slices.Contains(c.reconnectRelayAddresses, address) {
+		return
 	}
 	c.reconnectRelayAddresses = append(c.reconnectRelayAddresses, address)
 }
@@ -537,13 +531,7 @@ func (c *Client) reconnectRelayCandidates() []string {
 		candidates = append(candidates, c.relayControlAddress)
 	}
 	for _, address := range c.reconnectRelayAddresses {
-		seen := false
-		for _, candidate := range candidates {
-			if candidate == address {
-				seen = true
-				break
-			}
-		}
+		seen := slices.Contains(candidates, address)
 		if !seen {
 			candidates = append(candidates, address)
 		}
@@ -1813,7 +1801,7 @@ func (c *Client) Receive() (err error) {
 
 		if err == nil && len(discoveries) > 0 {
 			log.Debugf("all discoveries: %+v", discoveries)
-			for i := 0; i < len(discoveries); i++ {
+			for i := range discoveries {
 				log.Debugf("checking discovery result %d", i)
 				if !bytes.HasPrefix(discoveries[i].Payload, []byte("croc")) {
 					log.Debug("skipping discovery")
@@ -2935,10 +2923,7 @@ func formatDescription(description string) string {
 		}
 	}
 
-	maxDescription := width - progressMetaWidth
-	if maxDescription < minDescription {
-		maxDescription = minDescription
-	}
+	maxDescription := max(width-progressMetaWidth, minDescription)
 
 	runes := []rune(description)
 	if len(runes) > maxDescription {

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -52,8 +53,8 @@ func BenchmarkSenderChunkScheduling(b *testing.B) {
 		var sum int64
 		b.ReportMetric(float64(chunks*connections), "positions/op")
 		for n := 0; n < b.N; n++ {
-			for connection := int64(0); connection < connections; connection++ {
-				for chunk := int64(0); chunk < chunks; chunk++ {
+			for connection := range connections {
+				for chunk := range chunks {
 					if chunk%connections == connection {
 						sum += chunk * chunkSize
 					}
@@ -67,7 +68,7 @@ func BenchmarkSenderChunkScheduling(b *testing.B) {
 		b.ReportMetric(float64(chunks), "positions/op")
 		stride := chunkSize * connections
 		for n := 0; n < b.N; n++ {
-			for connection := int64(0); connection < connections; connection++ {
+			for connection := range connections {
 				for offset := connection * chunkSize; offset < fileSize; offset += stride {
 					sum += offset
 				}
@@ -94,7 +95,7 @@ func BenchmarkReceiveChunkWrites(b *testing.B) {
 	runWrites := func(lock *sync.Mutex) {
 		var wg sync.WaitGroup
 		wg.Add(connections)
-		for connection := 0; connection < connections; connection++ {
+		for connection := range connections {
 			go func(offset int64) {
 				defer wg.Done()
 				if lock != nil {
@@ -858,7 +859,7 @@ func TestCrocNonASCIIFileName(t *testing.T) {
 	go func() {
 		errCh <- receiver.Receive()
 	}()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if err := <-errCh; err != nil {
 			t.Errorf("transfer failed: %v", err)
 		}
@@ -985,7 +986,7 @@ func TestCrocRenameExistingFile(t *testing.T) {
 	go func() {
 		errCh <- receiver.Receive()
 	}()
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if err := <-errCh; err != nil {
 			t.Errorf("transfer failed: %v", err)
 		}
@@ -1257,13 +1258,7 @@ func TestGetFilesInfoZipFolderHonoursFilters(t *testing.T) {
 		}
 	}
 	wantKept := "myproj/main.go"
-	found := false
-	for _, name := range got {
-		if name == wantKept {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(got, wantKept)
 	if !found {
 		t.Errorf("expected %q in zip; got %v", wantKept, got)
 	}
@@ -1462,8 +1457,7 @@ func TestSenderAndReceiverPreferLocalRelayOverExternalRelay(t *testing.T) {
 		t.Skipf("local relay regression requires a non-loopback local IP: %v", err)
 	}
 	externalPorts := freeConsecutiveTestPorts(t, 5)
-	ctx, stopRelay := context.WithCancel(context.Background())
-	defer stopRelay()
+	ctx := t.Context()
 	go tcp.RunCtx(ctx, "warn", "127.0.0.1", externalPorts[0], "pass123", strings.Join(externalPorts[1:], ","))
 	for _, port := range externalPorts[1:] {
 		go tcp.RunCtx(ctx, "warn", "127.0.0.1", port, "pass123")
@@ -1522,7 +1516,7 @@ func TestSenderAndReceiverPreferLocalRelayOverExternalRelay(t *testing.T) {
 		errc <- receiver.Receive()
 	}()
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		if err := <-errc; err != nil {
 			t.Fatalf("transfer failed: %v", err)
 		}
@@ -1547,8 +1541,7 @@ func TestSenderLocalProbeDoesNotCorruptExternalRoute(t *testing.T) {
 
 	externalPorts := freeConsecutiveTestPortsForHost(t, externalHost, 9)
 	localPorts := freeConsecutiveTestPorts(t, 5)
-	ctx, stopRelay := context.WithCancel(context.Background())
-	defer stopRelay()
+	ctx := t.Context()
 	go tcp.RunCtx(ctx, "warn", externalHost, externalPorts[0], "pass123", strings.Join(externalPorts[1:], ","))
 	for _, port := range externalPorts[1:] {
 		go tcp.RunCtx(ctx, "warn", externalHost, port, "pass123")
@@ -1611,7 +1604,7 @@ func TestSenderLocalProbeDoesNotCorruptExternalRoute(t *testing.T) {
 		errc <- receiver.Receive()
 	}()
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case err := <-errc:
 			if err != nil {
@@ -1743,7 +1736,7 @@ func hashed(c *Client) bool {
 
 func waitHashed(sender *Client) (err error) {
 	err = fmt.Errorf("not hashed")
-	for i := 0; i < 300; i++ { // Max 3 seconds
+	for range 300 { // Max 3 seconds
 		if hashed(sender) {
 			time.Sleep(100 * time.Millisecond)
 			return nil
@@ -1760,7 +1753,7 @@ func createTestFile(t *testing.T, size int) (string, func()) {
 	}
 
 	data := make([]byte, size)
-	for i := 0; i < size; i++ {
+	for i := range size {
 		data[i] = byte(i % 256)
 	}
 
@@ -1797,12 +1790,12 @@ func freeConsecutiveTestPorts(t *testing.T, count int) []string {
 
 func freeConsecutiveTestPortsForHost(t *testing.T, host string, count int) []string {
 	t.Helper()
-	for attempts := 0; attempts < 100; attempts++ {
+	for range 100 {
 		base := 20000 + rand.Intn(20000)
 		listeners := make([]net.Listener, 0, count)
 		ports := make([]string, 0, count)
 		ok := true
-		for i := 0; i < count; i++ {
+		for i := range count {
 			port := strconv.Itoa(base + i)
 			listener, err := net.Listen("tcp", net.JoinHostPort(host, port))
 			if err != nil {
@@ -1927,7 +1920,7 @@ func runReconnectDropTest(t *testing.T, connIndex int, disableReceiverReconnect 
 	}()
 
 	var firstErr error
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case err := <-errc:
 			if err != nil && firstErr == nil {
@@ -2183,7 +2176,7 @@ func TestBase(t *testing.T) {
 	}()
 
 	go func() {
-		for i := 0; i < 3000; i++ {
+		for range 3000 {
 			if sender.Step1ChannelSecured && receiver.Step1ChannelSecured {
 				time.Sleep(time.Millisecond)
 				if sender.Step2FileInfoTransferred && receiver.Step2FileInfoTransferred {
@@ -2300,7 +2293,7 @@ func TestCtx(t *testing.T) {
 	}()
 
 	go func() {
-		for i := 0; i < 3000; i++ {
+		for range 3000 {
 			if sender.Step1ChannelSecured && receiver.Step1ChannelSecured {
 				time.Sleep(time.Millisecond)
 				if sender.Step2FileInfoTransferred && receiver.Step2FileInfoTransferred {
@@ -2441,7 +2434,7 @@ func TestAllCtx(t *testing.T) {
 	}()
 
 	go func() {
-		for i := 0; i < 3000; i++ {
+		for range 3000 {
 			if sender.Step1ChannelSecured && receiver.Step1ChannelSecured {
 				time.Sleep(time.Millisecond)
 				if sender.Step2FileInfoTransferred && receiver.Step2FileInfoTransferred {
@@ -2564,7 +2557,7 @@ func TestSendCtx(t *testing.T) {
 	}()
 
 	go func() {
-		for i := 0; i < 3000; i++ {
+		for range 3000 {
 			if sender.Step1ChannelSecured && receiver.Step1ChannelSecured {
 				time.Sleep(time.Millisecond)
 				if sender.Step2FileInfoTransferred && receiver.Step2FileInfoTransferred {
@@ -2687,7 +2680,7 @@ func TestReceiveCtx(t *testing.T) {
 	}()
 
 	go func() {
-		for i := 0; i < 3000; i++ {
+		for range 3000 {
 			if sender.Step1ChannelSecured && receiver.Step1ChannelSecured {
 				time.Sleep(time.Millisecond)
 				if sender.Step2FileInfoTransferred && receiver.Step2FileInfoTransferred {
@@ -2810,7 +2803,7 @@ func TestRunCtx(t *testing.T) {
 	}()
 
 	go func() {
-		for i := 0; i < 3000; i++ {
+		for range 3000 {
 			if sender.Step1ChannelSecured && receiver.Step1ChannelSecured {
 				time.Sleep(time.Millisecond)
 				if sender.Step2FileInfoTransferred && receiver.Step2FileInfoTransferred {

--- a/src/diskusage/diskusage.go
+++ b/src/diskusage/diskusage.go
@@ -1,5 +1,4 @@
 //go:build !windows && !netbsd
-// +build !windows,!netbsd
 
 package diskusage
 

--- a/src/mnemonicode/mnemonicode.go
+++ b/src/mnemonicode/mnemonicode.go
@@ -28,6 +28,8 @@
 
 package mnemonicode
 
+import "slices"
+
 const base = 1626
 
 // WordsRequired returns the number of words required to encode input
@@ -68,9 +70,9 @@ func EncodeWordList(dst []string, src []byte) (result []string) {
 	}
 	if len(src) > 0 {
 		x = 0
-		for i := len(src) - 1; i >= 0; i-- {
+		for _, s := range slices.Backward(src) {
 			x <<= 8
-			x |= uint32(src[i])
+			x |= uint32(s)
 		}
 		i := int(x % base)
 		result = append(result, WordList[i])

--- a/src/mnemonicode/mnemonicode_test.go
+++ b/src/mnemonicode/mnemonicode_test.go
@@ -1,6 +1,7 @@
 package mnemonicode
 
 import (
+	"slices"
 	"testing"
 )
 
@@ -86,7 +87,7 @@ func TestEncodeWordList(t *testing.T) {
 			if len(result) != tt.want {
 				t.Errorf("EncodeWordList() returned %d words, want %d", len(result), tt.want)
 			}
-			
+
 			// Check that all words are valid
 			for i, word := range result {
 				if word == "" {
@@ -99,15 +100,15 @@ func TestEncodeWordList(t *testing.T) {
 
 func TestEncodeWordListConsistency(t *testing.T) {
 	input := []byte{0x12, 0x34, 0x56, 0x78}
-	
+
 	// Encode twice with empty dst
 	result1 := EncodeWordList([]string{}, input)
 	result2 := EncodeWordList([]string{}, input)
-	
+
 	if len(result1) != len(result2) {
 		t.Errorf("Inconsistent result lengths: %d vs %d", len(result1), len(result2))
 	}
-	
+
 	for i := range result1 {
 		if result1[i] != result2[i] {
 			t.Errorf("Inconsistent result at index %d: %s vs %s", i, result1[i], result2[i])
@@ -120,13 +121,13 @@ func TestEncodeWordListCapacityHandling(t *testing.T) {
 	dst := make([]string, 1, 10)
 	dst[0] = "existing"
 	input := []byte{0x01, 0x02}
-	
+
 	result := EncodeWordList(dst, input)
-	
+
 	if len(result) != 3 { // 1 existing + 2 new
 		t.Errorf("Expected 3 words, got %d", len(result))
 	}
-	
+
 	if result[0] != "existing" {
 		t.Errorf("Expected first word to be 'existing', got %s", result[0])
 	}
@@ -143,25 +144,19 @@ func TestEncodeWordListBoundaryValues(t *testing.T) {
 		{"max four bytes", []byte{0xFF, 0xFF, 0xFF, 0xFF}},
 		{"all zeros", []byte{0x00, 0x00, 0x00, 0x00}},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := EncodeWordList([]string{}, tt.src)
 			expectedLen := WordsRequired(len(tt.src))
-			
+
 			if len(result) != expectedLen {
 				t.Errorf("Expected %d words, got %d", expectedLen, len(result))
 			}
-			
+
 			// Ensure all words are from the WordList
 			for _, word := range result {
-				found := false
-				for _, validWord := range WordList {
-					if word == validWord {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(WordList, word)
 				if !found {
 					t.Errorf("Invalid word generated: %s", word)
 				}

--- a/src/models/constants.go
+++ b/src/models/constants.go
@@ -120,7 +120,7 @@ func lookup(address string) (ipaddress string, err error) {
 			result <- r
 		}(dns)
 	}
-	for i := 0; i < len(publicDNS); i++ {
+	for range publicDNS {
 		ipaddress = (<-result).s
 		log.Tracef("Resolved %s to %s", address, ipaddress)
 		if ipaddress != "" {

--- a/src/models/models_test.go
+++ b/src/models/models_test.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"net"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -55,13 +56,7 @@ func TestPublicDNSServers(t *testing.T) {
 	}
 
 	for _, expected := range expectedServers {
-		found := false
-		for _, dns := range publicDNS {
-			if dns == expected {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(publicDNS, expected)
 		if !found {
 			t.Errorf("Expected DNS server %s not found in publicDNS", expected)
 		}

--- a/src/receivefs/root_test.go
+++ b/src/receivefs/root_test.go
@@ -120,9 +120,7 @@ func TestRootConcurrentFilesystemMutationCannotEscape(t *testing.T) {
 
 	stop := make(chan struct{})
 	var mutator sync.WaitGroup
-	mutator.Add(1)
-	go func() {
-		defer mutator.Done()
+	mutator.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -134,7 +132,7 @@ func TestRootConcurrentFilesystemMutationCannotEscape(t *testing.T) {
 			_ = os.Remove(parent)
 			_ = os.Mkdir(parent, 0o700)
 		}
-	}()
+	})
 	for range 500 {
 		_ = root.MkdirAll("parent/nested", 0o700)
 		file, openErr := root.OpenFile("parent/payload.txt", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)

--- a/src/store/service.go
+++ b/src/store/service.go
@@ -87,19 +87,19 @@ type metadata struct {
 	Version            int       `json:"version"`
 	ID                 string    `json:"id"`
 	State              state     `json:"state"`
-	CreatedAt          time.Time `json:"createdAt"`
-	UploadExpiresAt    time.Time `json:"uploadExpiresAt,omitempty"`
-	CompletedAt        time.Time `json:"completedAt,omitempty"`
-	ExpiresAt          time.Time `json:"expiresAt,omitempty"`
+	CreatedAt          time.Time `json:"createdAt,omitzero"`
+	UploadExpiresAt    time.Time `json:"uploadExpiresAt,omitzero"`
+	CompletedAt        time.Time `json:"completedAt,omitzero"`
+	ExpiresAt          time.Time `json:"expiresAt,omitzero"`
 	ExpiresSeconds     int64     `json:"expiresSeconds,omitempty"`
-	TombstoneExpiresAt time.Time `json:"tombstoneExpiresAt,omitempty"`
+	TombstoneExpiresAt time.Time `json:"tombstoneExpiresAt,omitzero"`
 	ManifestBytes      int64     `json:"manifestBytes"`
 	ChunkBytes         []int64   `json:"chunkBytes"`
 	ReservedBytes      int64     `json:"reservedBytes"`
 	UploadVerifier     string    `json:"uploadVerifier"`
 	RedeemVerifier     string    `json:"redeemVerifier"`
 	ClaimVerifier      string    `json:"claimVerifier,omitempty"`
-	ClaimExpiresAt     time.Time `json:"claimExpiresAt,omitempty"`
+	ClaimExpiresAt     time.Time `json:"claimExpiresAt,omitzero"`
 	DownloadsTotal     int       `json:"downloadsTotal,omitempty"`
 	DownloadsRemaining int       `json:"downloadsRemaining,omitempty"`
 	CommittedClaims    []string  `json:"committedClaims,omitempty"`
@@ -1018,10 +1018,7 @@ func (s *Service) claim(response http.ResponseWriter, request *http.Request, id 
 	}
 	now := s.now()
 	if meta.State == stateClaimed && meta.ClaimExpiresAt.After(now) {
-		seconds := int64(meta.ClaimExpiresAt.Sub(now).Seconds())
-		if seconds < 1 {
-			seconds = 1
-		}
+		seconds := max(int64(meta.ClaimExpiresAt.Sub(now).Seconds()), 1)
 		response.Header().Set("Retry-After", strconv.FormatInt(seconds, 10))
 		http.Error(response, "stored transfer is already claimed", http.StatusLocked)
 		return

--- a/src/store/service.go
+++ b/src/store/service.go
@@ -87,7 +87,7 @@ type metadata struct {
 	Version            int       `json:"version"`
 	ID                 string    `json:"id"`
 	State              state     `json:"state"`
-	CreatedAt          time.Time `json:"createdAt,omitzero"`
+	CreatedAt          time.Time `json:"createdAt"`
 	UploadExpiresAt    time.Time `json:"uploadExpiresAt,omitzero"`
 	CompletedAt        time.Time `json:"completedAt,omitzero"`
 	ExpiresAt          time.Time `json:"expiresAt,omitzero"`

--- a/src/store/service_test.go
+++ b/src/store/service_test.go
@@ -536,7 +536,7 @@ func TestUnknownTransferIDsUseBoundedLockState(t *testing.T) {
 	clock := &testClock{now: time.Unix(1_700_000_000, 0).UTC()}
 	service := newTestService(t, clock)
 
-	for index := 0; index < transferLockStripes*2; index++ {
+	for index := range transferLockStripes * 2 {
 		var raw [storecrypto.TransferIDLen]byte
 		binary.BigEndian.PutUint64(raw[8:], uint64(index))
 		id := storecrypto.EncodeBase64URL(raw[:])

--- a/src/storeclient/client.go
+++ b/src/storeclient/client.go
@@ -392,10 +392,7 @@ func prepareUpload(
 		prepared.manifest.Files[index] = file.manifest
 		remaining := file.info.Size()
 		for chunk := 0; chunk < file.manifest.ChunkCount; chunk++ {
-			size := int64(storecrypto.ChunkSize)
-			if remaining < size {
-				size = remaining
-			}
+			size := min(remaining, int64(storecrypto.ChunkSize))
 			prepared.chunkBytes = append(prepared.chunkBytes, size+28)
 			remaining -= size
 		}
@@ -591,9 +588,7 @@ func (c *Client) uploadFile(
 	var firstErr error
 	var fileSent int64
 	for range workerCount {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			chunkCipher, cipherErr := storecrypto.NewChunkCipher(result.Share.MasterKey)
 			if cipherErr != nil {
 				resultMu.Lock()
@@ -653,7 +648,7 @@ func (c *Client) uploadFile(
 				})
 				resultMu.Unlock()
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	return sent, firstErr
@@ -720,7 +715,7 @@ func hashReader(ctx context.Context, reader io.Reader) ([]byte, error) {
 
 func (c *Client) putWithRetry(ctx context.Context, target, token string, payload []byte) error {
 	var last error
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := range 3 {
 		request, err := http.NewRequestWithContext(ctx, http.MethodPut, target, bytes.NewReader(payload))
 		if err != nil {
 			return err
@@ -992,9 +987,7 @@ func (c *Client) writeFileChunks(
 	var wg sync.WaitGroup
 	var firstErr error
 	for range workerCount {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			chunkCipher, cipherErr := storecrypto.NewChunkCipher(session.share.MasterKey)
 			if cipherErr != nil {
 				session.stateMu.Lock()
@@ -1053,7 +1046,7 @@ func (c *Client) writeFileChunks(
 					return
 				}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	if firstErr != nil {

--- a/src/storeclient/client_test.go
+++ b/src/storeclient/client_test.go
@@ -177,7 +177,7 @@ func TestUploadWithMultipleDownloadsRemainsAvailableUntilLastCommit(t *testing.T
 	require.NoError(t, err)
 	assert.Equal(t, 3, result.Downloads)
 
-	for download := 0; download < 3; download++ {
+	for range 3 {
 		manifest, _, inspectErr := client.Inspect(context.Background(), result.Share)
 		require.NoError(t, inspectErr)
 		output := t.TempDir()

--- a/src/tcp/options.go
+++ b/src/tcp/options.go
@@ -2,6 +2,7 @@ package tcp
 
 import (
 	"fmt"
+	"slices"
 	"time"
 )
 
@@ -109,10 +110,5 @@ func WithRoomTTL(ttl time.Duration) serverOptsFunc {
 }
 
 func containsSlice(s []string, e string) bool {
-	for _, ss := range s {
-		if e == ss {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(s, e)
 }

--- a/src/tcp/tcp.go
+++ b/src/tcp/tcp.go
@@ -169,11 +169,9 @@ func (s *server) start() (err error) {
 	s.handshakeSlots = make(chan struct{}, s.maxPendingHandshakes)
 	s.admissionLimits = newAdmissionLimiter(s.sourceJoinLimit, s.roomJoinLimit, s.joinLimitWindow)
 
-	s.stop.wg.Add(1)
-	go func() {
-		defer s.stop.wg.Done()
+	s.stop.wg.Go(func() {
 		s.deleteOldRooms()
-	}()
+	})
 	// defer s.stopRoomDeletion()
 	defer s.stop.Cancel()
 	if s.stop.gui {

--- a/src/tcp/tcp_test.go
+++ b/src/tcp/tcp_test.go
@@ -140,7 +140,7 @@ func TestConcurrentRoomAdmissionRespectsWaitingRoomLimit(t *testing.T) {
 
 	start := make(chan struct{})
 	var wg sync.WaitGroup
-	for i := 0; i < 64; i++ {
+	for i := range 64 {
 		wg.Add(1)
 		go func(room int) {
 			defer wg.Done()

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -321,7 +321,7 @@ func LocalIP() string {
 
 // GenerateRandomPin returns a randomly generated pin with set length
 func GenerateRandomPin() string {
-	s := ""
+	var s strings.Builder
 	max := new(big.Int)
 	max.SetInt64(9)
 	for range NbPinNumbers {
@@ -329,9 +329,9 @@ func GenerateRandomPin() string {
 		if err != nil {
 			panic(err)
 		}
-		s += fmt.Sprintf("%d", v)
+		s.WriteString(fmt.Sprintf("%d", v))
 	}
-	return s
+	return s.String()
 }
 
 // GetRandomName returns a random three-word croc code.
@@ -480,10 +480,7 @@ func ChunkRangesBytes(chunkRanges []int64, fileSize, defaultChunkSize int64) int
 		if start < 0 || start >= fileSize || count <= 0 {
 			continue
 		}
-		end := start + count*chunkSize
-		if end > fileSize {
-			end = fileSize
-		}
+		end := min(start+count*chunkSize, fileSize)
 		if end > start {
 			total += end - start
 		}
@@ -888,7 +885,7 @@ func RejectSymlinkPath(root, target string) error {
 	}
 
 	current := rootAbs
-	for _, component := range strings.Split(rel, string(os.PathSeparator)) {
+	for component := range strings.SplitSeq(rel, string(os.PathSeparator)) {
 		current = filepath.Join(current, component)
 		info, statErr := os.Lstat(current)
 		if os.IsNotExist(statErr) {

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1399,8 +1400,7 @@ func TestHashFileCtxWithCancellation(t *testing.T) {
 
 	// Test 4: Imohash should be fast enough to complete before cancellation
 	t.Run("Imohash fast completion", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		// Imohash samples the file, so it should complete quickly
 		hash, err := HashFileCtx(ctx, "bigfile.test", "imohash", false)
@@ -1560,13 +1560,7 @@ func TestZipDirectoryHonoursExclusions(t *testing.T) {
 		}
 	}
 	wantKept := "src/main.go"
-	found := false
-	for _, name := range members {
-		if name == wantKept {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(members, wantKept)
 	if !found {
 		t.Errorf("expected %q in zip; got %v", wantKept, members)
 	}
@@ -1611,13 +1605,7 @@ func TestZipDirectoryHonoursIgnoredPaths(t *testing.T) {
 	}
 	wantKept := []string{"src/main.go", "src/build/output.bin"}
 	for _, want := range wantKept {
-		found := false
-		for _, name := range members {
-			if name == want {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(members, want)
 		if !found {
 			t.Errorf("expected %q in zip; got %v", want, members)
 		}

--- a/src/webcli/webcli.go
+++ b/src/webcli/webcli.go
@@ -166,7 +166,7 @@ func determinePass(value string) string {
 
 func parseRelayPorts(value string) []string {
 	var ports []string
-	for _, port := range strings.Split(value, ",") {
+	for port := range strings.SplitSeq(value, ",") {
 		if port = strings.TrimSpace(port); port != "" {
 			ports = append(ports, port)
 		}
@@ -176,7 +176,7 @@ func parseRelayPorts(value string) []string {
 
 func parseRelayHosts(value string) []string {
 	var hosts []string
-	for _, host := range strings.Split(value, ",") {
+	for host := range strings.SplitSeq(value, ",") {
 		if host = strings.TrimSpace(host); host != "" {
 			hosts = append(hosts, host)
 		}


### PR DESCRIPTION
Ran `go fix ./...`

- `// +build` syntax is redundant with `//go:build`
- `omitempty` tag had no effect on `time.Time`

---

```shell
go test ./...
```
```
?       github.com/schollz/croc/v11     [no test files]
?       github.com/schollz/croc/v11/cmd/croc-web        [no test files]
ok      github.com/schollz/croc/v11/internal/cli        (cached)
ok      github.com/schollz/croc/v11/src/cli     0.251s
ok      github.com/schollz/croc/v11/src/codephrase      (cached)
ok      github.com/schollz/croc/v11/src/comm    (cached)
ok      github.com/schollz/croc/v11/src/compress        (cached)
ok      github.com/schollz/croc/v11/src/croc    20.016s
ok      github.com/schollz/croc/v11/src/crypt   (cached)
ok      github.com/schollz/croc/v11/src/diskusage       (cached)
ok      github.com/schollz/croc/v11/src/install (cached)
ok      github.com/schollz/croc/v11/src/message (cached)
ok      github.com/schollz/croc/v11/src/mnemonicode     (cached)
ok      github.com/schollz/croc/v11/src/models  (cached)
ok      github.com/schollz/croc/v11/src/pakekey (cached)
ok      github.com/schollz/croc/v11/src/publicrelay     (cached)
ok      github.com/schollz/croc/v11/src/receivefs       (cached)
ok      github.com/schollz/croc/v11/src/redact  (cached)
ok      github.com/schollz/croc/v11/src/store   0.101s
ok      github.com/schollz/croc/v11/src/storeclient     0.158s
ok      github.com/schollz/croc/v11/src/storecrypto     (cached)
ok      github.com/schollz/croc/v11/src/tcp     (cached)
ok      github.com/schollz/croc/v11/src/termui  (cached)
ok      github.com/schollz/croc/v11/src/utils   2.518s
?       github.com/schollz/croc/v11/src/version [no test files]
ok      github.com/schollz/croc/v11/src/webassets       (cached)
ok      github.com/schollz/croc/v11/src/webcli  0.204s
ok      github.com/schollz/croc/v11/src/webrelay        0.078s
```