### PR TITLE
chore: go fix

### DIFF
--- a/internal/tailcat/wire_test.go
+++ b/internal/tailcat/wire_test.go
@@ -55,8 +55,8 @@ func TestWireFieldNames(t *testing.T) {
 		reflect.TypeFor[wireRegion](),
 		reflect.TypeFor[wireNode](),
 	} {
-		for i := range typ.NumField() {
-			f := typ.Field(i)
+		for f := range typ.Fields() {
+			f := f
 			short, _, _ := strings.Cut(f.Tag.Get("cbor"), ",")
 			if short == "" {
 				t.Errorf("%v.%s: missing cbor field name", typ, f.Name)

--- a/internal/tailcat/wire_test.go
+++ b/internal/tailcat/wire_test.go
@@ -56,7 +56,6 @@ func TestWireFieldNames(t *testing.T) {
 		reflect.TypeFor[wireNode](),
 	} {
 		for f := range typ.Fields() {
-			f := f
 			short, _, _ := strings.Cut(f.Tag.Get("cbor"), ",")
 			if short == "" {
 				t.Errorf("%v.%s: missing cbor field name", typ, f.Name)

--- a/src/croc/chunk_queue_test.go
+++ b/src/croc/chunk_queue_test.go
@@ -29,11 +29,9 @@ func TestRequestedChunkQueueLateWorkersClaimExactlyOnce(t *testing.T) {
 	}
 
 	var workers sync.WaitGroup
-	workers.Add(1)
-	go func() { defer workers.Done(); worker() }()
+	workers.Go(func() { ; worker() })
 	for range 7 {
-		workers.Add(1)
-		go func() { defer workers.Done(); worker() }()
+		workers.Go(func() { ; worker() })
 	}
 	workers.Wait()
 	if len(seen) != 101 {

--- a/src/croc/croc_test.go
+++ b/src/croc/croc_test.go
@@ -1880,11 +1880,9 @@ func startTestRelayWithContext(t *testing.T, ctx context.Context, dataPortCount 
 	dataPorts := append([]string(nil), ports[1:]...)
 	var relayWG sync.WaitGroup
 	start := func(port string, banner ...string) {
-		relayWG.Add(1)
-		go func() {
-			defer relayWG.Done()
+		relayWG.Go(func() {
 			_ = tcp.RunCtx(ctx, "warn", "127.0.0.1", port, "pass123", banner...)
-		}()
+		})
 	}
 	start(controlPort, strings.Join(dataPorts, ","))
 	for _, port := range dataPorts {

--- a/src/croc/relay_dial.go
+++ b/src/croc/relay_dial.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"slices"
 	"time"
 
 	"github.com/schollz/croc/v11/src/comm"
@@ -46,13 +47,7 @@ func raceRelayTCP(ctx context.Context, addresses []string, timeout, stagger time
 		if address == "" {
 			continue
 		}
-		seen := false
-		for _, existing := range unique {
-			if existing == address {
-				seen = true
-				break
-			}
-		}
+		seen := slices.Contains(unique, address)
 		if !seen {
 			unique = append(unique, address)
 		}

--- a/src/croc/tailcat_negotiation.go
+++ b/src/croc/tailcat_negotiation.go
@@ -540,8 +540,7 @@ func (c *Client) receiveTailcatStatus(deadline time.Time) (string, error) {
 
 func (c *Client) selectRelayAfterTailcatFailure(stage string, setupErr error, tokenValue string, attempt *transferAttemptState) error {
 	tailcatErr := c.tailcatError(stage, setupErr, tokenValue)
-	var protocolErr tailcatProtocolError
-	if errors.As(setupErr, &protocolErr) {
+	if _, ok := errors.AsType[tailcatProtocolError](setupErr); ok {
 		return tailcatErr
 	}
 	if !c.tailcatFallbackAllowed() {

--- a/src/logger/logger_test.go
+++ b/src/logger/logger_test.go
@@ -12,12 +12,12 @@ func TestConcurrentConfigurationAndLogging(t *testing.T) {
 	SetOutput(io.Discard)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
 			levels := []string{"trace", "debug", "info", "warn", "error"}
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				SetLevel(levels[(i+j)%len(levels)])
 				Debugf("worker %d iteration %d", i, j)
 			}

--- a/src/tcp/capability_test.go
+++ b/src/tcp/capability_test.go
@@ -2,7 +2,6 @@ package tcp
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"net"
 	"strconv"
@@ -166,8 +165,7 @@ func waitForRelayPort(t *testing.T, address string) {
 
 func TestFastRelayAdmissionAndLegacyFallback(t *testing.T) {
 	controlPort, dataPort := freeTCPPort(t), freeTCPPort(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	set, err := NewRelayCapabilitySet(1)
 	if err != nil {
 		t.Fatal(err)

--- a/src/utils/ctx.go
+++ b/src/utils/ctx.go
@@ -211,10 +211,7 @@ func imoHashV2Reader(sr *io.SectionReader, bar *progressbar.ProgressBar) ([]byte
 	}
 	buffer := make([]byte, windowSize)
 	for _, offset := range imoHashV2Offsets(size) {
-		length := min(windowSize, size-offset)
-		if length < 0 {
-			length = 0
-		}
+		length := max(min(windowSize, size-offset), 0)
 		binary.LittleEndian.PutUint64(encoded[:], uint64(offset))
 		_, _ = h.Write(encoded[:])
 		binary.LittleEndian.PutUint64(encoded[:], uint64(length))


### PR DESCRIPTION
```shell
go fix ./...
go test ./...
?   	github.com/schollz/croc/v11	[no test files]
?   	github.com/schollz/croc/v11/cmd/croc-web	[no test files]
ok  	github.com/schollz/croc/v11/internal/cli	(cached)
ok  	github.com/schollz/croc/v11/internal/tailcat	0.774s
ok  	github.com/schollz/croc/v11/src/cli	(cached)
ok  	github.com/schollz/croc/v11/src/codephrase	(cached)
ok  	github.com/schollz/croc/v11/src/comm	(cached)
ok  	github.com/schollz/croc/v11/src/compress	(cached)
ok  	github.com/schollz/croc/v11/src/croc	(cached)
ok  	github.com/schollz/croc/v11/src/crypt	(cached)
ok  	github.com/schollz/croc/v11/src/diskusage	(cached)
ok  	github.com/schollz/croc/v11/src/install	(cached)
ok  	github.com/schollz/croc/v11/src/logger	(cached)
ok  	github.com/schollz/croc/v11/src/message	(cached)
ok  	github.com/schollz/croc/v11/src/mnemonicode	(cached)
ok  	github.com/schollz/croc/v11/src/models	(cached)
ok  	github.com/schollz/croc/v11/src/pakekey	(cached)
ok  	github.com/schollz/croc/v11/src/publicrelay	(cached)
ok  	github.com/schollz/croc/v11/src/receivefs	(cached)
ok  	github.com/schollz/croc/v11/src/redact	(cached)
ok  	github.com/schollz/croc/v11/src/store	(cached)
ok  	github.com/schollz/croc/v11/src/storeclient	(cached)
ok  	github.com/schollz/croc/v11/src/storecrypto	(cached)
ok  	github.com/schollz/croc/v11/src/tailcattransport	(cached)
ok  	github.com/schollz/croc/v11/src/tcp	(cached)
ok  	github.com/schollz/croc/v11/src/termui	(cached)
ok  	github.com/schollz/croc/v11/src/utils	(cached)
?   	github.com/schollz/croc/v11/src/version	[no test files]
ok  	github.com/schollz/croc/v11/src/webassets	(cached)
ok  	github.com/schollz/croc/v11/src/webcli	(cached)
ok  	github.com/schollz/croc/v11/src/webrelay	(cached)
```