### PR TITLE
storecrypto: reject ChunkRef indices above uint32 range

### DIFF
--- a/src/storecrypto/storecrypto.go
+++ b/src/storecrypto/storecrypto.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"path"
 	"strings"
@@ -348,6 +349,9 @@ func (c *ChunkCipher) OpenInPlace(id string, ref ChunkRef, ciphertext []byte) ([
 func validateChunkRef(ref ChunkRef, plaintextLength int) error {
 	if ref.ObjectIndex < 0 || ref.FileIndex < 0 || ref.FileChunk < 0 {
 		return errors.New("stored-transfer chunk index cannot be negative")
+	}
+	if int64(ref.ObjectIndex) > math.MaxUint32 || int64(ref.FileIndex) > math.MaxUint32 || int64(ref.FileChunk) > math.MaxUint32 {
+		return errors.New("stored-transfer chunk index cannot be larger than 2^32-1")
 	}
 	if ref.PlainSize < 1 || ref.PlainSize > ChunkSize || plaintextLength != ref.PlainSize {
 		return errors.New("stored-transfer chunk has an invalid plaintext length")

--- a/src/storecrypto/storecrypto_test.go
+++ b/src/storecrypto/storecrypto_test.go
@@ -3,6 +3,7 @@ package storecrypto
 import (
 	"bytes"
 	"crypto/sha256"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -125,4 +126,22 @@ func TestValidateManifestRejectsUnsafeMetadata(t *testing.T) {
 	manifest := testManifest()
 	manifest.Files[0].FirstChunk = 4
 	assert.ErrorContains(t, ValidateManifest(manifest, 1024), "invalid chunk map")
+}
+
+func TestValidateChunkRefRejectsOutOfRangeIndex(t *testing.T) {
+    cases := []struct {
+        name string
+        ref  ChunkRef
+    }{
+        {"ObjectIndex too large", ChunkRef{ObjectIndex: math.MaxUint32 + 1, PlainSize: 4}},
+        {"FileIndex too large", ChunkRef{FileIndex: math.MaxUint32 + 1, PlainSize: 4}},
+        {"FileChunk too large", ChunkRef{FileChunk: math.MaxUint32 + 1, PlainSize: 4}},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            if err := validateChunkRef(tc.ref, 4); err == nil {
+                t.Fatalf("expected out-of-range index to be rejected")
+            }
+        })
+    }
 }


### PR DESCRIPTION
## storecrypto: enforce upper bound on ChunkRef indices

`validateChunkRef` checks that `ObjectIndex`, `FileIndex`, and `FileChunk` are
non-negative, but never checks an upper bound. These fields are later
truncated to `uint32` when building the chunk's AAD in `chunkAAD`:

```go
binary.BigEndian.PutUint32(data[offset:], uint32(ref.ObjectIndex))
```

The AAD's job is to bind a chunk's ciphertext to a unique logical position, and that binding
silently breaks since two `ChunkRef`s whose `ObjectIndex` differs by exactly `2^32` produce
byte-identical AAD.

### Reproduction

This snippet (not included in the diff) demonstrates the collision:

```go
func TestChunkAADCollidesAcrossUint32Boundary(t *testing.T) { // passes because AADs are byte-identical.
	// ObjectIndex is truncated to uint32 when building the AAD, so two logically distinct indices
	// exactly 2^32 apart produce byte-identical associated data.
	id := "demo-transfer-id"
	honest := ChunkRef{ObjectIndex: 3, FileIndex: 0, FileChunk: 3, PlainSize: 4}
	colliding := ChunkRef{ObjectIndex: 3 + (1 << 32), FileIndex: 0, FileChunk: 3, PlainSize: 4}

	if !bytes.Equal(chunkAAD(id, honest), chunkAAD(id, colliding)) {
		t.Fatal("expected chunkAAD to collide for indices differing by 2^32")
	}
}
```

### Where this is reachable
- The native Go client (`src/storeclient/client.go`) always derives
  `ChunkRef`s from `ChunkRefs(manifest)`, which is bounded by the validated
  manifest's total size, so it doesn't seem reachable there.
- The store/relay service never constructs a `ChunkRef` at all.
- The WASM/browser bridge (`web/wasm/main.go`, `storeChunkRef`) builds a `ChunkRef` 
  from JS-supplied integers with no validation of its own before calling `SealChunk`/`OpenChunk`, 
  so it relies on `validateChunkRef` to enforce the invariant.

### Fix

Add the missing upper bound, matching the `uint32` range the AAD encoding assumes.

### Test added

`TestValidateChunkRefRejectsOutOfRangeIndex` confirms out-of-range indices
are now rejected by `validateChunkRef`.